### PR TITLE
fix MaterializingResultSet iterator

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/resultset/order/MaterializingResultSet.java
+++ b/code/src/main/java/com/googlecode/cqengine/resultset/order/MaterializingResultSet.java
@@ -69,6 +69,9 @@ public class MaterializingResultSet<O> extends ResultSet<O> {
 
             @Override
             public boolean hasNext() {
+                if (nextObject != null) {
+                    return true;
+                }
                 while(wrappedIterator.hasNext()) {
                     O next = wrappedIterator.next();
                     if (next == null) {

--- a/code/src/test/java/com/googlecode/cqengine/resultset/order/MaterializingResultSetTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/resultset/order/MaterializingResultSetTest.java
@@ -1,0 +1,21 @@
+package com.googlecode.cqengine.resultset.order;
+
+import com.googlecode.cqengine.resultset.stored.StoredSetBasedResultSet;
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * @author dsmith
+ */
+public class MaterializingResultSetTest {
+    @Test
+    public void testMaterializingResultSetIterator() throws Exception {
+        final MaterializingResultSet<Object> set = new MaterializingResultSet<Object>(new StoredSetBasedResultSet<Object>(Collections.<Object>singleton(this)), null, null);
+        final Iterator<Object> it = set.iterator();
+        Assert.assertTrue(it.hasNext());
+        Assert.assertTrue(it.hasNext());
+    }
+}


### PR DESCRIPTION
There is currently a bug in `MaterializingResultSet` when `hasNext()` is called multiple times in a row.