### PR TITLE
Upgraded the version of sqlite-jdbc to 3.8.11.2. Use an alternative query (slightly more performant) to implement the 'contains' in the ResultSet created by the SQLiteIndex

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.10.1</version>
+            <version>3.8.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware</groupId>

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/support/DBQueries.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/support/DBQueries.java
@@ -559,18 +559,13 @@ public class DBQueries {
     }
 
     public static <K, O> boolean contains(final K objectKey, final Query<O> query, final String tableName, final Connection connection){
-        final String selectSql = String.format("SELECT COUNT(objectKey) FROM cqtbl_%s", tableName);
+        final String selectSql = String.format("SELECT objectKey FROM cqtbl_%s", tableName);
         PreparedStatement statement = null;
         try{
             List<WhereClause> additionalWhereClauses = Collections.singletonList(new WhereClause("objectKey = ?", objectKey));
-            statement = createAndBindSelectPreparedStatement(selectSql, "", additionalWhereClauses, query, connection);
+            statement = createAndBindSelectPreparedStatement(selectSql, " LIMIT 1", additionalWhereClauses, query, connection);
             java.sql.ResultSet resultSet = statement.executeQuery();
-
-            if (!resultSet.next()){
-                throw new IllegalStateException("Unable to execute contains. The ResultSet returned no row. Query: " + query);
-            }
-
-            return resultSet.getInt(1) > 0;
+            return resultSet.next();
         }catch (SQLException e){
             throw new IllegalStateException("Unable to execute contains. Query: " + query, e);
         }finally{

--- a/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIndexTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIndexTest.java
@@ -419,14 +419,12 @@ public class SQLiteIndexTest {
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class))).thenReturn(connectionContains).thenReturn(connectionDoNotContain);
-        when(connectionContains.prepareStatement("SELECT COUNT(objectKey) FROM " + TABLE_NAME + " WHERE value = ? AND objectKey = ?;")).thenReturn(preparedStatementContains);
-        when(connectionDoNotContain.prepareStatement("SELECT COUNT(objectKey) FROM " + TABLE_NAME + " WHERE value = ? AND objectKey = ?;")).thenReturn(preparedStatementDoNotContains);
+        when(connectionContains.prepareStatement("SELECT objectKey FROM " + TABLE_NAME + " WHERE value = ? AND objectKey = ? LIMIT 1;")).thenReturn(preparedStatementContains);
+        when(connectionDoNotContain.prepareStatement("SELECT objectKey FROM " + TABLE_NAME + " WHERE value = ? AND objectKey = ? LIMIT 1;")).thenReturn(preparedStatementDoNotContains);
         when(preparedStatementContains.executeQuery()).thenReturn(resultSetContains);
         when(preparedStatementDoNotContains.executeQuery()).thenReturn(resultSetDoNotContain);
         when(resultSetContains.next()).thenReturn(true).thenReturn(false);
-        when(resultSetContains.getInt(1)).thenReturn(1);
-        when(resultSetDoNotContain.next()).thenReturn(true).thenReturn(false);
-        when(resultSetDoNotContain.getInt(1)).thenReturn(0);
+        when(resultSetDoNotContain.next()).thenReturn(false);
 
         // Iterator
         ResultSet<Car> carsWithAbs = new SQLiteIndex<String, Car, Integer>(


### PR DESCRIPTION
Upgraded the version of sqlite-jdbc to 3.8.11.2. Use an alternative query (slightly more performant) to implement the 'contains' in the ResultSet created by the SQLiteIndex