### PR TITLE
Extract interfaces out of different specializations of attributes

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/attribute/IMultiValueAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/IMultiValueAttribute.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+public interface IMultiValueAttribute<O, A> extends Attribute<O, A> {
+    /**
+     * Returns the non-null values of the attribute from the object.
+     * <p/>
+     * @param object The object from which the values of the attribute are required
+     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
+     * this attribute to be invoked (either a query, or an update to the collection)
+     * @return The values for the attribute, which should never be null
+     */
+    @Override Iterable<A> getValues(O object, QueryOptions queryOptions);
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/IMultiValueNullableAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/IMultiValueNullableAttribute.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+public interface IMultiValueNullableAttribute<O, A> extends Attribute<O, A> {
+    /**
+     * Returns the values of the attribute from the object, omitting any null values.
+     * <p/>
+     * @param object The object from which the values of the attribute are required
+     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
+     * this attribute to be invoked (either a query, or an update to the collection)
+     * @return The values for the attribute
+     */
+    @Override Iterable<A> getValues(O object, QueryOptions queryOptions);
+
+    /**
+     * Returns the values of the attribute from the object, some of which can be null.
+     * The actual list returned can also be null.
+     * <p/>
+     * @param object The object from which the values of the attribute are required
+     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
+     * this attribute to be invoked (either a query, or an update to the collection)
+     * @return The values for the attribute, some of which might be null
+     */
+    Iterable<A> getNullableValues(O object, QueryOptions queryOptions);
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/IOrderControlAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/IOrderControlAttribute.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+public interface IOrderControlAttribute<O> extends Attribute<O, Integer>, ISimpleAttribute<O, Integer> {
+    Attribute<O, ?> getDelegateAttribute();
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/ISimpleAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/ISimpleAttribute.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+public interface ISimpleAttribute<O, A> extends Attribute<O, A> {
+    /**
+     * Returns the (non-null) value of the attribute from the object.
+     * <p/>
+     * @param object The object from which the value of the attribute is required
+     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
+     * this attribute to be invoked (either a query, or an update to the collection)
+     * @return The value for the attribute, which should never be null
+     */
+    A getValue(O object, QueryOptions queryOptions);
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/ISimpleNullableAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/ISimpleNullableAttribute.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+
+public interface ISimpleNullableAttribute<O, A> extends Attribute<O, A> {
+    /**
+     * Returns the (possibly null) value of the attribute from the object.
+     * <p/>
+     * @param object The object from which the value of the attribute is required
+     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
+     * this attribute to be invoked (either a query, or an update to the collection)
+     * @return The value for the attribute, which can be null
+     */
+    A getValue(O object, QueryOptions queryOptions);
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/IStandingQueryAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/IStandingQueryAttribute.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2012-2015 Niall Gallagher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.cqengine.attribute;
+
+import com.googlecode.cqengine.query.Query;
+
+public interface IStandingQueryAttribute<O> extends Attribute<O, Boolean>, IMultiValueAttribute<O, Boolean> {
+    Query<O> getQuery();
+}

--- a/code/src/main/java/com/googlecode/cqengine/attribute/MultiValueAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/MultiValueAttribute.java
@@ -16,7 +16,6 @@
 package com.googlecode.cqengine.attribute;
 
 import com.googlecode.cqengine.attribute.support.AbstractAttribute;
-import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
  * Represents an attribute in an object which has multiple values (such as a field which is itself a collection),
@@ -31,7 +30,7 @@ import com.googlecode.cqengine.query.option.QueryOptions;
  *
  * @author Niall Gallagher
  */
-public abstract class MultiValueAttribute<O, A> extends AbstractAttribute<O, A> {
+public abstract class MultiValueAttribute<O, A> extends AbstractAttribute<O, A> implements IMultiValueAttribute<O, A> {
 
     /**
      * Creates an attribute with the given name.
@@ -80,14 +79,4 @@ public abstract class MultiValueAttribute<O, A> extends AbstractAttribute<O, A> 
         super(objectType, attributeType, attributeName);
     }
 
-    /**
-     * Returns the non-null values of the attribute from the object.
-     * <p/>
-     * @param object The object from which the values of the attribute are required
-     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
-     * this attribute to be invoked (either a query, or an update to the collection)
-     * @return The values for the attribute, which should never be null
-     */
-    @Override
-    public abstract Iterable<A> getValues(O object, QueryOptions queryOptions);
 }

--- a/code/src/main/java/com/googlecode/cqengine/attribute/MultiValueNullableAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/MultiValueNullableAttribute.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
  *
  * @author Niall Gallagher
  */
-public abstract class MultiValueNullableAttribute<O, A> extends AbstractAttribute<O, A> {
+public abstract class MultiValueNullableAttribute<O, A> extends AbstractAttribute<O, A> implements IMultiValueNullableAttribute<O, A> {
 
     final boolean componentValuesNullable;
 
@@ -98,14 +98,6 @@ public abstract class MultiValueNullableAttribute<O, A> extends AbstractAttribut
         this.componentValuesNullable = componentValuesNullable;
     }
 
-    /**
-     * Returns the values of the attribute from the object, omitting any null values.
-     * <p/>
-     * @param object The object from which the values of the attribute are required
-     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
-     * this attribute to be invoked (either a query, or an update to the collection)
-     * @return The values for the attribute
-     */
     @Override
     public Iterable<A> getValues(O object, QueryOptions queryOptions) {
         Iterable<A> values = getNullableValues(object, queryOptions);
@@ -126,14 +118,4 @@ public abstract class MultiValueNullableAttribute<O, A> extends AbstractAttribut
         };
     }
 
-    /**
-     * Returns the values of the attribute from the object, some of which can be null.
-     * The actual list returned can also be null.
-     * <p/>
-     * @param object The object from which the values of the attribute are required
-     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
-     * this attribute to be invoked (either a query, or an update to the collection)
-     * @return The values for the attribute, some of which might be null
-     */
-    public abstract Iterable<A> getNullableValues(O object, QueryOptions queryOptions);
 }

--- a/code/src/main/java/com/googlecode/cqengine/attribute/OrderControlAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/OrderControlAttribute.java
@@ -44,19 +44,19 @@ import com.googlecode.cqengine.query.simple.Has;
  *
  * @author niall.gallagher
  */
-public abstract class OrderControlAttribute<O> extends SimpleAttribute<O, Integer> {
+public abstract class OrderControlAttribute<O> extends SimpleAttribute<O, Integer> implements IOrderControlAttribute<O> {
 
     protected final Attribute<O, ? extends Comparable> delegateAttribute;
 
     protected OrderControlAttribute(Attribute<O, ? extends Comparable> delegateAttribute, String delegateAttributeName) {
         super(delegateAttribute.getObjectType(), Integer.class, delegateAttributeName);
-        if (delegateAttribute instanceof OrderControlAttribute) {
+        if (delegateAttribute instanceof IOrderControlAttribute) {
             throw new IllegalArgumentException("Delegate attribute cannot also be an OrderControlAttribute: " + delegateAttribute);
         }
         this.delegateAttribute = delegateAttribute;
     }
 
-    public Attribute<O, ?> getDelegateAttribute() {
+    @Override public Attribute<O, ?> getDelegateAttribute() {
         return delegateAttribute;
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/attribute/SimpleAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/SimpleAttribute.java
@@ -28,7 +28,7 @@ import java.util.*;
  * @see SimpleNullableAttribute
  * @author Niall Gallagher
  */
-public abstract class SimpleAttribute<O, A> extends AbstractAttribute<O, A> {
+public abstract class SimpleAttribute<O, A> extends AbstractAttribute<O, A> implements ISimpleAttribute<O, A> {
 
     /**
      * Creates an attribute with no name. A name for the attribute will be generated automatically from the name of the
@@ -88,18 +88,8 @@ public abstract class SimpleAttribute<O, A> extends AbstractAttribute<O, A> {
         return Collections.singletonList(getValue(object, queryOptions));
     }
 
-    /**
-     * Returns the (non-null) value of the attribute from the object.
-     * <p/>
-     * @param object The object from which the value of the attribute is required
-     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
-     * this attribute to be invoked (either a query, or an update to the collection)
-     * @return The value for the attribute, which should never be null
-     */
-    public abstract A getValue(O object, QueryOptions queryOptions);
-
     @Override
     public boolean canEqual(Object other) {
-        return other instanceof SimpleAttribute;
+        return other instanceof ISimpleAttribute;
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/attribute/SimpleNullableAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/SimpleNullableAttribute.java
@@ -28,7 +28,7 @@ import java.util.*;
  * @see SimpleAttribute
  * @author Niall Gallagher
  */
-public abstract class SimpleNullableAttribute<O, A> extends AbstractAttribute<O, A> {
+public abstract class SimpleNullableAttribute<O, A> extends AbstractAttribute<O, A> implements ISimpleNullableAttribute<O, A> {
 
     /**
      * Creates an attribute with the given name.
@@ -87,13 +87,4 @@ public abstract class SimpleNullableAttribute<O, A> extends AbstractAttribute<O,
         return value == null ? Collections.<A>emptyList() : Collections.singletonList(value);
     }
 
-    /**
-     * Returns the (possibly null) value of the attribute from the object.
-     * <p/>
-     * @param object The object from which the value of the attribute is required
-     * @param queryOptions Optional parameters supplied by the application along with the operation which is causing
-     * this attribute to be invoked (either a query, or an update to the collection)
-     * @return The value for the attribute, which can be null
-     */
-    public abstract A getValue(O object, QueryOptions queryOptions);
 }

--- a/code/src/main/java/com/googlecode/cqengine/attribute/StandingQueryAttribute.java
+++ b/code/src/main/java/com/googlecode/cqengine/attribute/StandingQueryAttribute.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  *
  * @author niall.gallagher
  */
-public class StandingQueryAttribute<O> extends MultiValueAttribute<O, Boolean> {
+public class StandingQueryAttribute<O> extends MultiValueAttribute<O, Boolean> implements IStandingQueryAttribute<O> {
 
     final Query<O> standingQuery;
 
@@ -46,7 +46,7 @@ public class StandingQueryAttribute<O> extends MultiValueAttribute<O, Boolean> {
         throw new UnsupportedOperationException("Unsupported use of StandingQueryAttribute");
     }
 
-    public Query<O> getQuery() {
+    @Override public Query<O> getQuery() {
         return standingQuery;
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/engine/CollectionQueryEngine.java
+++ b/code/src/main/java/com/googlecode/cqengine/engine/CollectionQueryEngine.java
@@ -148,9 +148,9 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
             @SuppressWarnings({"unchecked"})
             AttributeIndex<?, O> attributeIndex = (AttributeIndex<?, O>) index;
             Attribute<O, ?> indexedAttribute = attributeIndex.getAttribute();
-            if (indexedAttribute instanceof StandingQueryAttribute) {
+            if (indexedAttribute instanceof IStandingQueryAttribute) {
                 @SuppressWarnings("unchecked")
-                StandingQueryAttribute<O> standingQueryAttribute = (StandingQueryAttribute<O>) indexedAttribute;
+                IStandingQueryAttribute<O> standingQueryAttribute = (IStandingQueryAttribute<O>) indexedAttribute;
                 Query<O> standingQuery = standingQueryAttribute.getQuery();
                 addStandingQueryIndex(index, standingQuery, queryOptions);
             }
@@ -359,9 +359,9 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
                 AttributeOrder<O> firstOrder = allSortOrders.iterator().next();
                 @SuppressWarnings("unchecked")
                 Attribute<O, Comparable> firstAttribute = (Attribute<O, Comparable>)firstOrder.getAttribute();
-                if (firstAttribute instanceof OrderControlAttribute) {
+                if (firstAttribute instanceof IOrderControlAttribute) {
                     @SuppressWarnings("unchecked")
-                    Attribute<O, Comparable> firstAttributeDelegate = ((OrderControlAttribute)firstAttribute).getDelegateAttribute();
+                    Attribute<O, Comparable> firstAttributeDelegate = ((IOrderControlAttribute)firstAttribute).getDelegateAttribute();
                     firstAttribute = firstAttributeDelegate;
                 }
 
@@ -379,7 +379,7 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
                 // ordering results, we must return those objects either before or after the objects which are found in
                 // the index. Here we proceed to locate a suitable index to use for ordering results, only if we will
                 // also be able to retrieve the objects missing from that index efficiently as well...
-                if (firstAttribute instanceof SimpleAttribute || standingQueryIndexes.get(not(has(firstAttribute))) != null) {
+                if (firstAttribute instanceof ISimpleAttribute || standingQueryIndexes.get(not(has(firstAttribute))) != null) {
                     // Either we are sorting by a SimpleAttribute, or we are sorting by a non-SimpleAttribute and we
                     // also will be able to retrieve objects which do not have values for the non-SimpleAttribute
                     // efficiently. Now check if an index exists which would allow index ordering...
@@ -513,9 +513,9 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
         // If the client wrapped the first attribute by which results should be ordered in an OrderControlAttribute,
         // assign it here...
         @SuppressWarnings("unchecked")
-        final OrderControlAttribute<O> orderControlAttribute =
-                (primarySortOrder.getAttribute() instanceof OrderControlAttribute)
-                        ? (OrderControlAttribute<O>)primarySortOrder.getAttribute() : null;
+        final IOrderControlAttribute<O> orderControlAttribute =
+                (primarySortOrder.getAttribute() instanceof IOrderControlAttribute)
+                        ? (IOrderControlAttribute<O>)primarySortOrder.getAttribute() : null;
 
         // If the first attribute by which results should be ordered was wrapped, unwrap it, and assign it here...
         @SuppressWarnings("unchecked")
@@ -526,8 +526,8 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
 
         final boolean primarySortDescending = primarySortOrder.isDescending();
 
-        final boolean attributeCanHaveZeroValues = !(primarySortAttribute instanceof SimpleAttribute);
-        final boolean attributeCanHaveMoreThanOneValue = !(primarySortAttribute instanceof SimpleAttribute || primarySortAttribute instanceof SimpleNullableAttribute);
+        final boolean attributeCanHaveZeroValues = !(primarySortAttribute instanceof ISimpleAttribute);
+        final boolean attributeCanHaveMoreThanOneValue = !(primarySortAttribute instanceof ISimpleAttribute || primarySortAttribute instanceof ISimpleNullableAttribute);
 
         @SuppressWarnings("unchecked")
         final RangeBounds<?> rangeBoundsFromQuery = getBoundsFromQuery(query, primarySortAttribute);

--- a/code/src/main/java/com/googlecode/cqengine/index/radixinverted/InvertedRadixTreeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/radixinverted/InvertedRadixTreeIndex.java
@@ -20,9 +20,7 @@ import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
 import com.googlecode.concurrenttrees.radixinverted.ConcurrentInvertedRadixTree;
 import com.googlecode.concurrenttrees.radixinverted.InvertedRadixTree;
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.AbstractAttributeIndex;
 import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
@@ -252,7 +250,7 @@ public class InvertedRadixTreeIndex<A extends CharSequence, O> extends AbstractA
      */
     ResultSet<O> unionResultSets(Iterable<? extends ResultSet<O>> results, Query<O> query, QueryOptions queryOptions) {
         if (DeduplicationOption.isLogicalElimination(queryOptions)
-                && !(getAttribute() instanceof SimpleAttribute || getAttribute() instanceof SimpleNullableAttribute)) {
+                && !(getAttribute() instanceof ISimpleAttribute || getAttribute() instanceof ISimpleNullableAttribute)) {
             return new ResultSetUnion<O>(results, query, queryOptions) {
                 @Override
                 public int getRetrievalCost() {

--- a/code/src/main/java/com/googlecode/cqengine/index/radixreversed/ReversedRadixTreeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/radixreversed/ReversedRadixTreeIndex.java
@@ -20,9 +20,7 @@ import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
 import com.googlecode.concurrenttrees.radixreversed.ConcurrentReversedRadixTree;
 import com.googlecode.concurrenttrees.radixreversed.ReversedRadixTree;
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.AbstractAttributeIndex;
 import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
@@ -252,7 +250,7 @@ public class ReversedRadixTreeIndex<A extends CharSequence, O> extends AbstractA
      */
     ResultSet<O> unionResultSets(Iterable<? extends ResultSet<O>> results, Query<O> query, QueryOptions queryOptions) {
         if (DeduplicationOption.isLogicalElimination(queryOptions)
-                && !(getAttribute() instanceof SimpleAttribute || getAttribute() instanceof SimpleNullableAttribute)) {
+                && !(getAttribute() instanceof ISimpleAttribute || getAttribute() instanceof ISimpleNullableAttribute)) {
             return new ResultSetUnion<O>(results, query, queryOptions) {
                 @Override
                 public int getRetrievalCost() {

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/IdentityAttributeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/IdentityAttributeIndex.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.cqengine.index.sqlite;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.AttributeIndex;
 
 /**
@@ -30,5 +30,5 @@ public interface IdentityAttributeIndex<A, O> extends AttributeIndex<A, O> {
      * object from the identity index. This is called a foreign key attribute, because typically those keys will
      * be stored in other indexes, referring to the primary keys of this index.
      */
-    SimpleAttribute<A, O> getForeignKeyAttribute();
+    ISimpleAttribute<A,O> getForeignKeyAttribute();
 }

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/PartialSQLiteIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/PartialSQLiteIndex.java
@@ -17,6 +17,7 @@ package com.googlecode.cqengine.index.sqlite;
 
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.PartialIndex;
 import com.googlecode.cqengine.index.support.PartialSortedKeyStatisticsAttributeIndex;
@@ -33,8 +34,8 @@ import static com.googlecode.cqengine.index.sqlite.support.DBUtils.sanitizeForTa
  */
 public class PartialSQLiteIndex<A extends Comparable<A>, O, K> extends PartialSortedKeyStatisticsAttributeIndex<A, O> implements NonHeapTypeIndex {
 
-    final SimpleAttribute<O, K> primaryKeyAttribute;
-    final SimpleAttribute<K, O> foreignKeyAttribute;
+    final ISimpleAttribute<O,K> primaryKeyAttribute;
+    final ISimpleAttribute<K,O> foreignKeyAttribute;
     final String tableNameSuffix;
 
     /**
@@ -46,8 +47,8 @@ public class PartialSQLiteIndex<A extends Comparable<A>, O, K> extends PartialSo
      * @param filterQuery The filter query which matches the subset of objects to be stored in this index.
      */
     protected PartialSQLiteIndex(Attribute<O, A> attribute,
-                                 SimpleAttribute<O, K> primaryKeyAttribute,
-                                 SimpleAttribute<K, O> foreignKeyAttribute,
+                                 ISimpleAttribute<O,K> primaryKeyAttribute,
+                                 ISimpleAttribute<K,O> foreignKeyAttribute,
                                  Query<O> filterQuery) {
         super(attribute, filterQuery);
         this.primaryKeyAttribute = primaryKeyAttribute;
@@ -81,8 +82,8 @@ public class PartialSQLiteIndex<A extends Comparable<A>, O, K> extends PartialSo
      * @return a new instance of the {@link SQLiteIndex}
      */
     public static <A extends Comparable<A>, O, K> PartialSQLiteIndex<A, O, K> onAttributeWithFilterQuery(Attribute<O, A> attribute,
-                                                                                   SimpleAttribute<O, K> primaryKeyAttribute,
-                                                                                   SimpleAttribute<K, O> foreignKeyAttribute,
+                                                                                   ISimpleAttribute<O,K> primaryKeyAttribute,
+                                                                                   ISimpleAttribute<K,O> foreignKeyAttribute,
                                                                                    Query<O> filterQuery) {
         return new PartialSQLiteIndex<A, O, K>(attribute, primaryKeyAttribute, foreignKeyAttribute, filterQuery);
     }

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndex.java
@@ -20,6 +20,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.*;
 import com.googlecode.cqengine.index.support.indextype.NonHeapTypeIndex;
@@ -53,10 +54,10 @@ public class SQLiteIdentityIndex<A extends Comparable<A>, O> implements Identity
 
     final SQLiteIndex<A, O, byte[]> sqLiteIndex;
     final Class<O> objectType;
-    final SimpleAttribute<O, A> primaryKeyAttribute;
-    final SimpleAttribute<A, O> foreignKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
+    final ISimpleAttribute<A,O> foreignKeyAttribute;
 
-    public SQLiteIdentityIndex(final SimpleAttribute<O, A> primaryKeyAttribute) {
+    public SQLiteIdentityIndex(final ISimpleAttribute<O,A> primaryKeyAttribute) {
         this.sqLiteIndex = new SQLiteIndex<A, O, byte[]>(
                 primaryKeyAttribute,
                 new SerializingAttribute(primaryKeyAttribute.getObjectType(), byte[].class),
@@ -73,7 +74,7 @@ public class SQLiteIdentityIndex<A extends Comparable<A>, O> implements Identity
         this.foreignKeyAttribute = new ForeignKeyAttribute();
     }
 
-    public SimpleAttribute<A, O> getForeignKeyAttribute() {
+    public ISimpleAttribute<A,O> getForeignKeyAttribute() {
         return foreignKeyAttribute;
     }
 
@@ -296,7 +297,7 @@ public class SQLiteIdentityIndex<A extends Comparable<A>, O> implements Identity
      * @param <O> The type of the object containing the attributes.
      * @return a new instance of a standalone {@link SQLiteIdentityIndex}
      */
-    public static <A extends Comparable<A>, O> SQLiteIdentityIndex<A, O> onAttribute(final SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <A extends Comparable<A>, O> SQLiteIdentityIndex<A, O> onAttribute(final ISimpleAttribute<O,A> primaryKeyAttribute) {
         return new SQLiteIdentityIndex<A, O>(primaryKeyAttribute);
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIndex.java
@@ -16,10 +16,7 @@
 package com.googlecode.cqengine.index.sqlite;
 
 import com.googlecode.concurrenttrees.common.LazyIterator;
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.MultiValueAttribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.disk.DiskIndex;
 import com.googlecode.cqengine.index.offheap.OffHeapIndex;
@@ -115,8 +112,8 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
     static final int INDEX_RETRIEVAL_COST_FILTERING = INDEX_RETRIEVAL_COST + 1;
 
     final String tableName;
-    final SimpleAttribute<O, K> primaryKeyAttribute;
-    final SimpleAttribute<K, O> foreignKeyAttribute;
+    final ISimpleAttribute<O,K> primaryKeyAttribute;
+    final ISimpleAttribute<K,O> foreignKeyAttribute;
 
     SQLiteConfig.SynchronousMode pragmaSynchronous;
     SQLiteConfig.JournalMode pragmaJournalMode;
@@ -134,8 +131,8 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
      *                        {@link DBUtils#sanitizeForTableName(String)}
      */
     public SQLiteIndex(final Attribute<O, A> attribute,
-                       final SimpleAttribute<O, K> primaryKeyAttribute,
-                       final SimpleAttribute<K, O> foreignKeyAttribute,
+                       final ISimpleAttribute<O,K> primaryKeyAttribute,
+                       final ISimpleAttribute<K,O> foreignKeyAttribute,
                        final String tableNameSuffix) {
 
         super(attribute, new HashSet<Class<? extends Query>>() {{
@@ -381,7 +378,7 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
                 public int size() {
                     final Connection connection = connectionManager.getConnection(SQLiteIndex.this, queryOptions);
 
-                    boolean attributeHasAtMostOneValue = (attribute instanceof SimpleAttribute || attribute instanceof SimpleNullableAttribute);
+                    boolean attributeHasAtMostOneValue = (attribute instanceof ISimpleAttribute || attribute instanceof ISimpleNullableAttribute);
                     boolean queryIsADisjointInQuery = query instanceof In && ((In) query).isDisjoint();
 
                     if (queryIsADisjointInQuery || attributeHasAtMostOneValue) {
@@ -479,7 +476,7 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
      * @return {@link Iterable} of {@link Row}s.
      */
     static <O, K, A> Iterable<Row< K, A>> rowIterable(final Iterable<O> objects,
-                                                      final SimpleAttribute<O, K> primaryKeyAttribute,
+                                                      final ISimpleAttribute<O,K> primaryKeyAttribute,
                                                       final Attribute<O, A> indexAttribute,
                                                       final QueryOptions queryOptions){
         return new Iterable<Row<K, A>>() {
@@ -566,7 +563,7 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
      * @return {@link Iterable} over the objects ids.
      */
     static <O, K> Iterable<K> objectKeyIterable(final Iterable<O> objects,
-                                                final SimpleAttribute<O, K> primaryKeyAttribute,
+                                                final ISimpleAttribute<O,K> primaryKeyAttribute,
                                                 final QueryOptions queryOptions){
         return new Iterable<K>() {
 
@@ -880,8 +877,8 @@ public class SQLiteIndex<A extends Comparable<A>, O, K> extends AbstractAttribut
      * @return a new instance of the {@link SQLiteIndex}
      */
     public static <A extends Comparable<A>, O, K> SQLiteIndex<A, O, K> onAttribute(final Attribute<O, A> attribute,
-                                                                                   final SimpleAttribute<O, K> objectKeyAttribute,
-                                                                                   final SimpleAttribute<K, O> foreignKeyAttribute) {
+                                                                                   final ISimpleAttribute<O,K> objectKeyAttribute,
+                                                                                   final ISimpleAttribute<K,O> foreignKeyAttribute) {
         return new SQLiteIndex<A, O, K>(attribute, objectKeyAttribute, foreignKeyAttribute, "");
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/SimplifiedSQLiteIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/SimplifiedSQLiteIndex.java
@@ -17,6 +17,7 @@ package com.googlecode.cqengine.index.sqlite;
 
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.engine.QueryEngine;
 import com.googlecode.cqengine.index.AttributeIndex;
 import com.googlecode.cqengine.index.Index;
@@ -56,9 +57,9 @@ public abstract class SimplifiedSQLiteIndex<A extends Comparable<A>, O, K extend
         Persistence<O, K> persistence = SimplifiedSQLiteIndex.<O, K>getPersistenceFromQueryOptions(queryOptions);
         QueryEngine<O> queryEngine = getQueryEngineFromQueryOptions(queryOptions);
 
-        final SimpleAttribute<O, K> primaryKeyAttribute = getPrimaryKeyFromPersistence(persistence);
+        final ISimpleAttribute<O,K> primaryKeyAttribute = getPrimaryKeyFromPersistence(persistence);
         final AttributeIndex<K, O> primaryKeyIndex = getPrimaryKeyIndexFromQueryEngine(primaryKeyAttribute, queryEngine, queryOptions);
-        final SimpleAttribute<K, O> foreignKeyAttribute = new SimpleAttribute<K, O>(primaryKeyAttribute.getAttributeType(), primaryKeyAttribute.getObjectType()) {
+        final ISimpleAttribute<K,O> foreignKeyAttribute = new SimpleAttribute<K, O>(primaryKeyAttribute.getAttributeType(), primaryKeyAttribute.getObjectType()) {
             @Override
             public O getValue(K primaryKeyValue, QueryOptions queryOptions) {
                 return primaryKeyIndex.retrieve(QueryFactory.equal(primaryKeyAttribute, primaryKeyValue), queryOptions).uniqueResult();
@@ -97,15 +98,15 @@ public abstract class SimplifiedSQLiteIndex<A extends Comparable<A>, O, K extend
         return queryEngine;
     }
 
-    SimpleAttribute<O, K> getPrimaryKeyFromPersistence(Persistence<O, K> persistence) {
-        SimpleAttribute<O, K> primaryKey = persistence.getPrimaryKeyAttribute();
+    ISimpleAttribute<O,K> getPrimaryKeyFromPersistence(Persistence<O, K> persistence) {
+        ISimpleAttribute<O,K> primaryKey = persistence.getPrimaryKeyAttribute();
         if (primaryKey == null) {
             throw new IllegalStateException("This index " + getClass().getSimpleName() + " on attribute '" + attribute.getAttributeName() + "' cannot be added to the IndexedCollection, because the configured persistence was not configured with a primary key attribute.");
         }
         return primaryKey;
     }
 
-    AttributeIndex<K, O> getPrimaryKeyIndexFromQueryEngine(SimpleAttribute<O, K> primaryKeyAttribute, QueryEngine<O> queryEngine, QueryOptions queryOptions) {
+    AttributeIndex<K, O> getPrimaryKeyIndexFromQueryEngine(ISimpleAttribute<O,K> primaryKeyAttribute, QueryEngine<O> queryEngine, QueryOptions queryOptions) {
         for (Index<O> index : queryEngine.getIndexes()) {
             if (index instanceof AttributeIndex) {
                 @SuppressWarnings("unchecked")

--- a/code/src/main/java/com/googlecode/cqengine/index/suffix/SuffixTreeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/suffix/SuffixTreeIndex.java
@@ -20,9 +20,7 @@ import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
 import com.googlecode.concurrenttrees.suffix.ConcurrentSuffixTree;
 import com.googlecode.concurrenttrees.suffix.SuffixTree;
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.AbstractAttributeIndex;
 import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
@@ -306,7 +304,7 @@ public class SuffixTreeIndex<A extends CharSequence, O> extends AbstractAttribut
      */
     ResultSet<O> unionResultSets(Iterable<? extends ResultSet<O>> results, Query<O> query, QueryOptions queryOptions) {
         if (DeduplicationOption.isLogicalElimination(queryOptions)
-                && !(getAttribute() instanceof SimpleAttribute || getAttribute() instanceof SimpleNullableAttribute)) {
+                && !(getAttribute() instanceof ISimpleAttribute || getAttribute() instanceof ISimpleNullableAttribute)) {
             return new ResultSetUnion<O>(results, query, queryOptions) {
                 @Override
                 public int getRetrievalCost() {

--- a/code/src/main/java/com/googlecode/cqengine/index/support/IndexSupport.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/support/IndexSupport.java
@@ -15,9 +15,7 @@
  */
 package com.googlecode.cqengine.index.support;
 
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.DeduplicationOption;
 import com.googlecode.cqengine.query.option.QueryOptions;
@@ -61,7 +59,7 @@ public class IndexSupport {
                                                              final QueryOptions queryOptions,
                                                              final int retrievalCost) {
         boolean logicalElimination = DeduplicationOption.isLogicalElimination(queryOptions);
-        boolean attributeHasAtMostOneValue = (attribute instanceof SimpleAttribute || attribute instanceof SimpleNullableAttribute);
+        boolean attributeHasAtMostOneValue = (attribute instanceof ISimpleAttribute || attribute instanceof ISimpleNullableAttribute);
         boolean queryIsADisjointInQuery = query instanceof In && ((In) query).isDisjoint();
         if (!logicalElimination || attributeHasAtMostOneValue || queryIsADisjointInQuery) {
             // No need to deduplicate...

--- a/code/src/main/java/com/googlecode/cqengine/persistence/Persistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/Persistence.java
@@ -15,12 +15,10 @@
  */
 package com.googlecode.cqengine.persistence;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.persistence.support.ObjectStore;
 import com.googlecode.cqengine.query.option.QueryOptions;
-
-import java.util.Set;
 
 /**
  * An interface with multiple implementations, which provide details on how a collection or indexes should be persisted
@@ -76,5 +74,5 @@ public interface Persistence<O, A extends Comparable<A>> {
      * @return the primary key attribute, if configured. This may be null for some persistence implementations
      * especially on-heap persistence.
      */
-    SimpleAttribute<O, A> getPrimaryKeyAttribute();
+    ISimpleAttribute<O,A> getPrimaryKeyAttribute();
 }

--- a/code/src/main/java/com/googlecode/cqengine/persistence/composite/CompositePersistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/composite/CompositePersistence.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.cqengine.persistence.composite;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.sqlite.ConnectionManager;
 import com.googlecode.cqengine.index.sqlite.RequestScopeConnectionManager;
@@ -62,7 +62,7 @@ public class CompositePersistence<O, A extends Comparable<A>> implements Persist
     }
 
     @Override
-    public SimpleAttribute<O, A> getPrimaryKeyAttribute() {
+    public ISimpleAttribute<O,A> getPrimaryKeyAttribute() {
         return primaryPersistence.getPrimaryKeyAttribute();
     }
 
@@ -135,7 +135,7 @@ public class CompositePersistence<O, A extends Comparable<A>> implements Persist
      * @param additionalPersistences Zero or more Persistence objects to be validated
      */
     static <O, A extends Comparable<A>> void validatePersistenceArguments(Persistence<O, A> primaryPersistence, Persistence<O, A> secondaryPersistence, List<? extends Persistence<O, A>> additionalPersistences) {
-        SimpleAttribute<O, A> primaryKeyAttribute;
+        ISimpleAttribute<O,A> primaryKeyAttribute;
         primaryKeyAttribute = validatePersistenceArgument(primaryPersistence, null);
         primaryKeyAttribute = validatePersistenceArgument(secondaryPersistence, primaryKeyAttribute);
         for (Persistence<O, A> additionalPersistence : additionalPersistences) {
@@ -147,7 +147,7 @@ public class CompositePersistence<O, A extends Comparable<A>> implements Persist
      * Helper method for {@link #validatePersistenceArguments(Persistence, Persistence, List)}. See documentation of
      * that method for details.
      */
-    static <O, A extends Comparable<A>> SimpleAttribute<O, A> validatePersistenceArgument(Persistence<O, A> persistence, SimpleAttribute<O, A> primaryKeyAttribute) {
+    static <O, A extends Comparable<A>> ISimpleAttribute<O,A> validatePersistenceArgument(Persistence<O, A> persistence, ISimpleAttribute<O,A> primaryKeyAttribute) {
         if (persistence == null) {
             throw new NullPointerException("The Persistence argument cannot be null.");
         }

--- a/code/src/main/java/com/googlecode/cqengine/persistence/disk/DiskPersistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/disk/DiskPersistence.java
@@ -15,9 +15,8 @@
  */
 package com.googlecode.cqengine.persistence.disk;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
-import com.googlecode.cqengine.index.disk.DiskIndex;
 import com.googlecode.cqengine.index.sqlite.ConnectionManager;
 import com.googlecode.cqengine.index.sqlite.RequestScopeConnectionManager;
 import com.googlecode.cqengine.index.sqlite.SQLitePersistence;
@@ -35,7 +34,6 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import static com.googlecode.cqengine.query.QueryFactory.noQueryOptions;
 
@@ -48,7 +46,7 @@ import static com.googlecode.cqengine.query.QueryFactory.noQueryOptions;
  * underlying SQLite database file by default (see that link for more details).
  * <p/>
  * Optionally, this class allows the application to override the journal mode or other settings in SQLite by
- * supplying <i>"override properties"</i> to the {@link #onPrimaryKeyInFileWithProperties(SimpleAttribute, File, Properties)}
+ * supplying <i>"override properties"</i> to the {@link #onPrimaryKeyInFileWithProperties(ISimpleAttribute, File, Properties)}
  * method. As WAL mode is suitable for most applications, most applications should work best with the default settings;
  * the override support is intended for advanced or custom use cases.
  *
@@ -56,7 +54,7 @@ import static com.googlecode.cqengine.query.QueryFactory.noQueryOptions;
  */
 public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersistence<O, A> {
 
-    final SimpleAttribute<O, A> primaryKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
     final File file;
     final SQLiteDataSource sqLiteDataSource;
 
@@ -66,7 +64,7 @@ public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersis
         DEFAULT_PROPERTIES.setProperty("journal_mode", "WAL"); // Use Write-Ahead-Logging which supports concurrent reads and writes
     }
 
-    protected DiskPersistence(SimpleAttribute<O, A> primaryKeyAttribute, File file, Properties overrideProperties) {
+    protected DiskPersistence(ISimpleAttribute<O,A> primaryKeyAttribute, File file, Properties overrideProperties) {
         Properties effectiveProperties = new Properties();
         effectiveProperties.putAll(DEFAULT_PROPERTIES);
         effectiveProperties.putAll(overrideProperties);
@@ -80,7 +78,7 @@ public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersis
     }
 
     @Override
-    public SimpleAttribute<O, A> getPrimaryKeyAttribute() {
+    public ISimpleAttribute<O,A> getPrimaryKeyAttribute() {
         return primaryKeyAttribute;
     }
 
@@ -231,9 +229,9 @@ public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersis
      *
      * @param primaryKeyAttribute An attribute which returns the primary key of objects in the collection
      * @return A {@link DiskPersistence} object which persists to a temp file on disk
-     * @see #onPrimaryKeyInFile(SimpleAttribute, File)
+     * @see #onPrimaryKeyInFile(ISimpleAttribute, File)
      */
-    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKey(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKey(ISimpleAttribute<O,A> primaryKeyAttribute) {
         return DiskPersistence.onPrimaryKeyInFile(primaryKeyAttribute, createTempFile());
     }
 
@@ -244,7 +242,7 @@ public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersis
      * @param file The file on disk to which data should be persisted
      * @return A {@link DiskPersistence} object which persists to the given file on disk
      */
-    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKeyInFile(SimpleAttribute<O, A> primaryKeyAttribute, File file) {
+    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKeyInFile(ISimpleAttribute<O,A> primaryKeyAttribute, File file) {
         return DiskPersistence.onPrimaryKeyInFileWithProperties(primaryKeyAttribute, file, new Properties());
     }
 
@@ -257,7 +255,7 @@ public class DiskPersistence<O, A extends Comparable<A>> implements SQLitePersis
      *                           settings, but cannot be null)
      * @return A {@link DiskPersistence} object which persists to the given file on disk
      */
-    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKeyInFileWithProperties(SimpleAttribute<O, A> primaryKeyAttribute, File file, Properties overrideProperties) {
+    public static <O, A extends Comparable<A>> DiskPersistence<O, A> onPrimaryKeyInFileWithProperties(ISimpleAttribute<O,A> primaryKeyAttribute, File file, Properties overrideProperties) {
         return new DiskPersistence<O, A>(primaryKeyAttribute, file, overrideProperties);
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/persistence/offheap/OffHeapPersistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/offheap/OffHeapPersistence.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.persistence.offheap;
 
 import com.googlecode.cqengine.IndexedCollection;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.sqlite.ConnectionManager;
 import com.googlecode.cqengine.index.sqlite.RequestScopeConnectionManager;
@@ -95,7 +95,7 @@ public class OffHeapPersistence<O, A extends Comparable<A>> implements SQLitePer
 
     static final AtomicInteger INSTANCE_ID_GENERATOR = new AtomicInteger();
 
-    final SimpleAttribute<O, A> primaryKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
     final String instanceName;
     final SQLiteDataSource sqLiteDataSource;
 
@@ -107,7 +107,7 @@ public class OffHeapPersistence<O, A extends Comparable<A>> implements SQLitePer
     volatile Connection persistentConnection;
     volatile boolean closed = false;
 
-    protected OffHeapPersistence(SimpleAttribute<O, A> primaryKeyAttribute, Properties overrideProperties) {
+    protected OffHeapPersistence(ISimpleAttribute<O,A> primaryKeyAttribute, Properties overrideProperties) {
         Properties effectiveProperties = new Properties(DEFAULT_PROPERTIES);
         effectiveProperties.putAll(overrideProperties);
         SQLiteConfig sqLiteConfig = new SQLiteConfig(effectiveProperties);
@@ -122,7 +122,7 @@ public class OffHeapPersistence<O, A extends Comparable<A>> implements SQLitePer
     }
 
     @Override
-    public SimpleAttribute<O, A> getPrimaryKeyAttribute() {
+    public ISimpleAttribute<O,A> getPrimaryKeyAttribute() {
         return primaryKeyAttribute;
     }
 
@@ -329,7 +329,7 @@ public class OffHeapPersistence<O, A extends Comparable<A>> implements SQLitePer
      * @param primaryKeyAttribute An attribute which returns the primary key of objects in the collection
      * @return An {@link OffHeapPersistence} object which persists to native memory
      */
-    public static <O, A extends Comparable<A>> OffHeapPersistence<O, A> onPrimaryKey(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <O, A extends Comparable<A>> OffHeapPersistence<O, A> onPrimaryKey(ISimpleAttribute<O,A> primaryKeyAttribute) {
         return OffHeapPersistence.onPrimaryKeyWithProperties(primaryKeyAttribute, new Properties());
     }
 
@@ -342,7 +342,7 @@ public class OffHeapPersistence<O, A extends Comparable<A>> implements SQLitePer
      *                           settings, but cannot be null)
      * @return An {@link OffHeapPersistence} object which persists to native memory
      */
-    public static <O, A extends Comparable<A>> OffHeapPersistence<O, A> onPrimaryKeyWithProperties(SimpleAttribute<O, A> primaryKeyAttribute, Properties overrideProperties) {
+    public static <O, A extends Comparable<A>> OffHeapPersistence<O, A> onPrimaryKeyWithProperties(ISimpleAttribute<O,A> primaryKeyAttribute, Properties overrideProperties) {
         return new OffHeapPersistence<O, A>(primaryKeyAttribute, overrideProperties);
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/persistence/onheap/OnHeapPersistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/onheap/OnHeapPersistence.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.cqengine.persistence.onheap;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
 import com.googlecode.cqengine.persistence.Persistence;
@@ -30,7 +30,7 @@ import com.googlecode.cqengine.query.option.QueryOptions;
  */
 public class OnHeapPersistence<O, A extends Comparable<A>> implements Persistence<O, A> {
 
-    final SimpleAttribute<O, A> primaryKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
     final int initialCapacity;
     final float loadFactor;
     final int concurrencyLevel;
@@ -39,11 +39,11 @@ public class OnHeapPersistence<O, A extends Comparable<A>> implements Persistenc
         this(null, 16, 0.75F, 16);
     }
 
-    public OnHeapPersistence(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public OnHeapPersistence(ISimpleAttribute<O,A> primaryKeyAttribute) {
         this(primaryKeyAttribute, 16, 0.75F, 16);
     }
 
-    public OnHeapPersistence(SimpleAttribute<O, A> primaryKeyAttribute, int initialCapacity, float loadFactor, int concurrencyLevel) {
+    public OnHeapPersistence(ISimpleAttribute<O,A> primaryKeyAttribute, int initialCapacity, float loadFactor, int concurrencyLevel) {
         this.primaryKeyAttribute = primaryKeyAttribute;
         this.initialCapacity = initialCapacity;
         this.loadFactor = loadFactor;
@@ -80,7 +80,7 @@ public class OnHeapPersistence<O, A extends Comparable<A>> implements Persistenc
     }
 
     @Override
-    public SimpleAttribute<O, A> getPrimaryKeyAttribute() {
+    public ISimpleAttribute<O,A> getPrimaryKeyAttribute() {
         return primaryKeyAttribute;
     }
 
@@ -90,7 +90,7 @@ public class OnHeapPersistence<O, A extends Comparable<A>> implements Persistenc
      * @param primaryKeyAttribute An attribute which returns the primary key of objects in the collection
      * @return An {@link OnHeapPersistence} object which persists to the Java heap.
      */
-    public static <O, A extends Comparable<A>> OnHeapPersistence<O, A> onPrimaryKey(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <O, A extends Comparable<A>> OnHeapPersistence<O, A> onPrimaryKey(ISimpleAttribute<O,A> primaryKeyAttribute) {
         return new OnHeapPersistence<O, A>(primaryKeyAttribute);
     }
 
@@ -100,7 +100,7 @@ public class OnHeapPersistence<O, A extends Comparable<A>> implements Persistenc
      * <p/>
      * This persistence will not work with composite persistence configurations, where some indexes are located on heap,
      * and some off-heap etc. To use this persistence in those configurations, it is necessary to specify a primary
-     * key - see: {@link #onPrimaryKey(SimpleAttribute)}.
+     * key - see: {@link #onPrimaryKey(ISimpleAttribute)}.
      *
      * @return An {@link OnHeapPersistence} object which persists to the Java heap, and which is not configured with
      * a primary key.

--- a/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteDiskIdentityIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteDiskIdentityIndex.java
@@ -16,6 +16,7 @@
 package com.googlecode.cqengine.persistence.support.sqlite;
 
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.sqlite.SQLiteIdentityIndex;
 import com.googlecode.cqengine.index.support.indextype.DiskTypeIndex;
@@ -29,7 +30,7 @@ import com.googlecode.cqengine.index.support.indextype.DiskTypeIndex;
  */
 public class SQLiteDiskIdentityIndex<A extends Comparable<A>, O> extends SQLiteIdentityIndex<A, O> implements DiskTypeIndex{
 
-    public SQLiteDiskIdentityIndex(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public SQLiteDiskIdentityIndex(ISimpleAttribute<O,A> primaryKeyAttribute) {
         super(primaryKeyAttribute);
     }
 
@@ -46,7 +47,7 @@ public class SQLiteDiskIdentityIndex<A extends Comparable<A>, O> extends SQLiteI
      * @param <O> The type of the object containing the attributes.
      * @return a new instance of {@link SQLiteDiskIdentityIndex}
      */
-    public static <A extends Comparable<A>, O> SQLiteDiskIdentityIndex<A, O> onAttribute(final SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <A extends Comparable<A>, O> SQLiteDiskIdentityIndex<A, O> onAttribute(final ISimpleAttribute<O,A> primaryKeyAttribute) {
         return new SQLiteDiskIdentityIndex<A, O>(primaryKeyAttribute);
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteObjectStore.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteObjectStore.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.cqengine.persistence.support.sqlite;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.sqlite.SQLiteIdentityIndex;
 import com.googlecode.cqengine.index.sqlite.SQLitePersistence;
 import com.googlecode.cqengine.index.support.CloseableIterator;
@@ -37,7 +37,7 @@ public class SQLiteObjectStore<O, A extends Comparable<A>> implements ObjectStor
 
     final SQLitePersistence<O, A> persistence;
     final SQLiteIdentityIndex<A, O> backingIndex;
-    final SimpleAttribute<O, A> primaryKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
     final Class<O> objectType;
 
     public SQLiteObjectStore(final SQLitePersistence<O, A> persistence) {

--- a/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteOffHeapIdentityIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/support/sqlite/SQLiteOffHeapIdentityIndex.java
@@ -16,6 +16,7 @@
 package com.googlecode.cqengine.persistence.support.sqlite;
 
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.sqlite.SQLiteIdentityIndex;
 import com.googlecode.cqengine.index.support.indextype.OffHeapTypeIndex;
@@ -29,7 +30,7 @@ import com.googlecode.cqengine.index.support.indextype.OffHeapTypeIndex;
  */
 public class SQLiteOffHeapIdentityIndex<A extends Comparable<A>, O> extends SQLiteIdentityIndex<A, O> implements OffHeapTypeIndex {
 
-    public SQLiteOffHeapIdentityIndex(SimpleAttribute<O, A> primaryKeyAttribute) {
+    public SQLiteOffHeapIdentityIndex(ISimpleAttribute<O,A> primaryKeyAttribute) {
         super(primaryKeyAttribute);
     }
 
@@ -46,7 +47,7 @@ public class SQLiteOffHeapIdentityIndex<A extends Comparable<A>, O> extends SQLi
      * @param <O> The type of the object containing the attributes.
      * @return a new instance of {@link SQLiteOffHeapIdentityIndex}
      */
-    public static <A extends Comparable<A>, O> SQLiteOffHeapIdentityIndex<A, O> onAttribute(final SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <A extends Comparable<A>, O> SQLiteOffHeapIdentityIndex<A, O> onAttribute(final ISimpleAttribute<O,A> primaryKeyAttribute) {
         return new SQLiteOffHeapIdentityIndex<A, O>(primaryKeyAttribute);
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/persistence/wrapping/WrappingPersistence.java
+++ b/code/src/main/java/com/googlecode/cqengine/persistence/wrapping/WrappingPersistence.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.persistence.wrapping;
 
 import com.googlecode.cqengine.IndexedCollection;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.support.indextype.OnHeapTypeIndex;
 import com.googlecode.cqengine.persistence.Persistence;
@@ -60,13 +60,13 @@ import java.util.Collection;
 public class WrappingPersistence<O, A extends Comparable<A>> implements Persistence<O, A> {
 
     final Collection<O> backingCollection;
-    final SimpleAttribute<O, A> primaryKeyAttribute;
+    final ISimpleAttribute<O,A> primaryKeyAttribute;
 
     public WrappingPersistence(Collection<O> backingCollection) {
         this(backingCollection, null);
     }
 
-    public WrappingPersistence(Collection<O> backingCollection, SimpleAttribute<O, A> primaryKeyAttribute) {
+    public WrappingPersistence(Collection<O> backingCollection, ISimpleAttribute<O,A> primaryKeyAttribute) {
         this.backingCollection = backingCollection;
         this.primaryKeyAttribute = primaryKeyAttribute;
     }
@@ -101,7 +101,7 @@ public class WrappingPersistence<O, A extends Comparable<A>> implements Persiste
     }
 
     @Override
-    public SimpleAttribute<O, A> getPrimaryKeyAttribute() {
+    public ISimpleAttribute<O,A> getPrimaryKeyAttribute() {
         return primaryKeyAttribute;
     }
 
@@ -111,7 +111,7 @@ public class WrappingPersistence<O, A extends Comparable<A>> implements Persiste
      * @param primaryKeyAttribute An attribute which returns the primary key of objects in the collection
      * @return A {@link WrappingPersistence} object which persists to the given collection.
      */
-    public static <O, A extends Comparable<A>> WrappingPersistence<O, A> aroundCollectionOnPrimaryKey(Collection<O> collection, SimpleAttribute<O, A> primaryKeyAttribute) {
+    public static <O, A extends Comparable<A>> WrappingPersistence<O, A> aroundCollectionOnPrimaryKey(Collection<O> collection, ISimpleAttribute<O,A> primaryKeyAttribute) {
         return new WrappingPersistence<O, A>(collection, primaryKeyAttribute);
     }
 
@@ -121,7 +121,7 @@ public class WrappingPersistence<O, A extends Comparable<A>> implements Persiste
      * <p/>
      * This persistence will not work with composite persistence configurations, where some indexes are located on heap,
      * and some off-heap etc. To use this persistence in those configurations, it is necessary to specify a primary
-     * key - see: {@link #aroundCollectionOnPrimaryKey(Collection, SimpleAttribute)}.
+     * key - see: {@link #aroundCollectionOnPrimaryKey(Collection, ISimpleAttribute)}.
      *
      * @return A {@link WrappingPersistence} object which persists to the given collection, and which is not configured
      * with a primary key.

--- a/code/src/main/java/com/googlecode/cqengine/query/QueryFactory.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/QueryFactory.java
@@ -169,7 +169,7 @@ public class QueryFactory {
      * @return An {@link In} query
      */
     public static <O, A> Query<O> in(Attribute<O, A> attribute, Collection<A> attributeValues) {
-        return in(attribute, attribute instanceof SimpleAttribute, attributeValues);
+        return in(attribute, attribute instanceof ISimpleAttribute, attributeValues);
     }
 
     /**
@@ -779,7 +779,7 @@ public class QueryFactory {
      * @param standingQuery The standing query to encapsulate
      * @return a {@link StandingQueryAttribute} encapsulating the given query
      */
-    public static <O> StandingQueryAttribute<O> forStandingQuery(Query<O> standingQuery) {
+    public static <O> IStandingQueryAttribute<O> forStandingQuery(Query<O> standingQuery) {
         return new StandingQueryAttribute<O>(standingQuery);
     }
 
@@ -794,7 +794,7 @@ public class QueryFactory {
      * @return a {@link StandingQueryAttribute} which returns true if the given attribute does not have values for
      * an object
      */
-    public static <O, A> StandingQueryAttribute<O> forObjectsMissing(Attribute<O, A> attribute) {
+    public static <O, A> IStandingQueryAttribute<O> forObjectsMissing(Attribute<O, A> attribute) {
         return forStandingQuery(not(has(attribute)));
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/option/AttributeOrder.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/option/AttributeOrder.java
@@ -15,10 +15,7 @@
  */
 package com.googlecode.cqengine.query.option;
 
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.OrderControlAttribute;
-import com.googlecode.cqengine.attribute.OrderMissingFirstAttribute;
-import com.googlecode.cqengine.attribute.OrderMissingLastAttribute;
+import com.googlecode.cqengine.attribute.*;
 
 /**
  * Represents an attribute and an associated preference for sorting results according to that attribute
@@ -49,7 +46,7 @@ public class AttributeOrder<O> {
     @Override
     public String toString() {
         if (attribute instanceof OrderMissingLastAttribute) {
-            OrderControlAttribute orderControlAttribute = (OrderControlAttribute) attribute;
+            IOrderControlAttribute orderControlAttribute = (IOrderControlAttribute) attribute;
             @SuppressWarnings("unchecked")
             Attribute<O, ? extends Comparable> delegateAttribute = orderControlAttribute.getDelegateAttribute();
             return descending
@@ -57,7 +54,7 @@ public class AttributeOrder<O> {
                     : "ascending(missingLast(" + delegateAttribute.getObjectType().getSimpleName() + "." + delegateAttribute.getAttributeName() + "))";
         }
         if (attribute instanceof OrderMissingFirstAttribute) {
-            OrderControlAttribute orderControlAttribute = (OrderControlAttribute) attribute;
+            IOrderControlAttribute orderControlAttribute = (IOrderControlAttribute) attribute;
             @SuppressWarnings("unchecked")
             Attribute<O, ? extends Comparable> delegateAttribute = orderControlAttribute.getDelegateAttribute();
             return descending

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/All.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/All.java
@@ -17,7 +17,7 @@ package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SelfAttribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -37,7 +37,7 @@ public class All<O> extends SimpleQuery<O, O> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, O> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,O> attribute, O object, QueryOptions queryOptions) {
         return true;
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/Between.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/Between.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -77,7 +77,7 @@ public class Between<O, A extends Comparable<A>> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         if (lowerInclusive && upperInclusive) {
             if (lowerValue.compareTo(attributeValue) <= 0 && upperValue.compareTo(attributeValue) >= 0) {

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/Equal.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/Equal.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -45,7 +45,7 @@ public class Equal<O, A> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         return value.equals(attribute.getValue(object, queryOptions));
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/ExistsIn.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/ExistsIn.java
@@ -17,7 +17,7 @@ package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
@@ -51,7 +51,7 @@ final IndexedCollection<F> foreignCollection;
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A localValue = attribute.getValue(object, queryOptions);
         return foreignRestrictions == null
                 ? foreignCollection.retrieve(equal(foreignKeyAttribute, localValue)).isNotEmpty()

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/GreaterThan.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/GreaterThan.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -60,7 +60,7 @@ public class GreaterThan<O, A extends Comparable<A>> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         if (valueInclusive) {
             return value.compareTo(attributeValue) <= 0;

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/Has.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/Has.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -39,7 +39,7 @@ public class Has<O, A> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         return attribute.getValue(object, queryOptions) != null;
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/In.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/In.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.util.Set;
@@ -48,7 +48,7 @@ public class In<O, A> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         return values.contains(attribute.getValue(object, queryOptions));
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/LessThan.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/LessThan.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -60,7 +60,7 @@ public class LessThan<O, A extends Comparable<A>> extends SimpleQuery<O, A> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         if (valueInclusive) {
             return value.compareTo(attributeValue) >= 0;

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/None.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/None.java
@@ -17,7 +17,7 @@ package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SelfAttribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -37,7 +37,7 @@ public class None<O> extends SimpleQuery<O, O> {
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, O> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,O> attribute, O object, QueryOptions queryOptions) {
         return false;
     }
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/SimpleQuery.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/SimpleQuery.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.Query;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
@@ -32,7 +32,7 @@ public abstract class SimpleQuery<O, A> implements Query<O> {
 
     protected final boolean attributeIsSimple;
     protected final Attribute<O, A> attribute;
-    protected final SimpleAttribute<O, A> simpleAttribute;
+    protected final ISimpleAttribute<O,A> simpleAttribute;
     // Lazy calculate and cache hash code...
     private transient int cachedHashCode = 0;
 
@@ -45,9 +45,9 @@ public abstract class SimpleQuery<O, A> implements Query<O> {
             throw new IllegalArgumentException("The attribute argument was null.");
         }
         this.attribute = attribute;
-        if (attribute instanceof SimpleAttribute) {
+        if (attribute instanceof ISimpleAttribute) {
             this.attributeIsSimple = true;
-            this.simpleAttribute = (SimpleAttribute<O, A>) attribute;
+            this.simpleAttribute = (ISimpleAttribute<O,A>) attribute;
         }
         else {
             this.attributeIsSimple = false;
@@ -91,7 +91,7 @@ public abstract class SimpleQuery<O, A> implements Query<O> {
         }
     }
 
-    protected abstract boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions);
+    protected abstract boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions);
 
     protected abstract boolean matchesNonSimpleAttribute(Attribute<O, A> attribute, O object, QueryOptions queryOptions);
 

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/StringContains.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/StringContains.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -45,7 +45,7 @@ public class StringContains<O, A extends CharSequence> extends SimpleQuery<O, A>
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         CharSequence attributeValue = attribute.getValue(object, queryOptions);
         return containsFragment(attributeValue, value);
     }

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/StringEndsWith.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/StringEndsWith.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -45,7 +45,7 @@ public class StringEndsWith<O, A extends CharSequence> extends SimpleQuery<O, A>
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         return matchesValue(attributeValue, queryOptions);
     }

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/StringIsContainedIn.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/StringIsContainedIn.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -45,7 +45,7 @@ public class StringIsContainedIn<O, A extends CharSequence> extends SimpleQuery<
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         CharSequence attributeValue = attribute.getValue(object, queryOptions);
         // Same as string contains, except we swap the arguments...
         return StringContains.containsFragment(value, attributeValue);

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/StringMatchesRegex.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/StringMatchesRegex.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.util.regex.Pattern;
@@ -48,7 +48,7 @@ public class StringMatchesRegex<O, A extends CharSequence> extends SimpleQuery<O
 
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         return matchesValue(attributeValue, queryOptions);
     }

--- a/code/src/main/java/com/googlecode/cqengine/query/simple/StringStartsWith.java
+++ b/code/src/main/java/com/googlecode/cqengine/query/simple/StringStartsWith.java
@@ -16,7 +16,7 @@
 package com.googlecode.cqengine.query.simple;
 
 import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 /**
@@ -45,7 +45,7 @@ public class StringStartsWith<O, A extends CharSequence> extends SimpleQuery<O, 
     }
 
     @Override
-    protected boolean matchesSimpleAttribute(SimpleAttribute<O, A> attribute, O object, QueryOptions queryOptions) {
+    protected boolean matchesSimpleAttribute(ISimpleAttribute<O,A> attribute, O object, QueryOptions queryOptions) {
         A attributeValue = attribute.getValue(object, queryOptions);
         return matchesValue(attributeValue, queryOptions);
     }

--- a/code/src/main/java/com/googlecode/cqengine/resultset/order/AttributeOrdersComparator.java
+++ b/code/src/main/java/com/googlecode/cqengine/resultset/order/AttributeOrdersComparator.java
@@ -46,8 +46,8 @@ public class AttributeOrdersComparator<O> implements Comparator<O> {
         for (AttributeOrder<O> attributeOrder : attributeSortOrders) {
             Attribute<O, ? extends Comparable> attribute = attributeOrder.getAttribute();
             int comparison;
-            if (attribute instanceof OrderControlAttribute) {
-                OrderControlAttribute<O> orderControl = (OrderControlAttribute<O>)(OrderControlAttribute)(attribute);
+            if (attribute instanceof IOrderControlAttribute) {
+                IOrderControlAttribute<O> orderControl = (IOrderControlAttribute)(attribute);
                 comparison = orderControl.getValue(o1, queryOptions).compareTo(orderControl.getValue(o2, queryOptions));
                 if (comparison != 0) {
                     // One of the objects has values for the delegate attribute encapsulated in OrderControlAttribute,
@@ -93,9 +93,9 @@ public class AttributeOrdersComparator<O> implements Comparator<O> {
     }
 
     <A extends Comparable<A>> int compareAttributeValues(Attribute<O, A> attribute, O o1, O o2) {
-        if (attribute instanceof SimpleAttribute) {
+        if (attribute instanceof ISimpleAttribute) {
             // Fast code path...
-            SimpleAttribute<O, A> simpleAttribute = (SimpleAttribute<O, A>)attribute;
+            ISimpleAttribute<O,A> simpleAttribute = (ISimpleAttribute<O,A>)attribute;
             return simpleAttribute.getValue(o1, queryOptions).compareTo(simpleAttribute.getValue(o2, queryOptions));
         }
         else {

--- a/code/src/test/java/com/googlecode/cqengine/IndexedCollectionFunctionalTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/IndexedCollectionFunctionalTest.java
@@ -15,9 +15,7 @@
  */
 package com.googlecode.cqengine;
 
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.attribute.StandingQueryAttribute;
+import com.googlecode.cqengine.attribute.*;
 import com.googlecode.cqengine.index.AttributeIndex;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.compound.support.CompoundValueTuple;
@@ -43,8 +41,6 @@ import com.googlecode.cqengine.persistence.composite.CompositePersistence;
 import com.googlecode.cqengine.persistence.disk.DiskPersistence;
 import com.googlecode.cqengine.persistence.offheap.OffHeapPersistence;
 import com.googlecode.cqengine.persistence.onheap.OnHeapPersistence;
-import com.googlecode.cqengine.persistence.support.sqlite.SQLiteDiskIdentityIndex;
-import com.googlecode.cqengine.persistence.support.sqlite.SQLiteOffHeapIdentityIndex;
 import com.googlecode.cqengine.quantizer.IntegerQuantizer;
 import com.googlecode.cqengine.quantizer.Quantizer;
 import com.googlecode.cqengine.query.Query;
@@ -1301,7 +1297,7 @@ public class IndexedCollectionFunctionalTest {
         );
     }
 
-    private static SimpleAttribute<Integer, Car> createForeignKeyAttribute() {
+    private static ISimpleAttribute<Integer,Car> createForeignKeyAttribute() {
         return new SimpleAttribute<Integer, Car>() {
             @Override
             public Car getValue(final Integer carId, final QueryOptions queryOptions) {
@@ -1776,7 +1772,7 @@ public class IndexedCollectionFunctionalTest {
         }
         else if (index instanceof AttributeIndex) {
             Attribute attribute = ((AttributeIndex) index).getAttribute();
-            if (attribute instanceof StandingQueryAttribute) {
+            if (attribute instanceof IStandingQueryAttribute) {
                 description += ".onAttribute(" + attribute.getAttributeName() + ")";
             }
             else {

--- a/code/src/test/java/com/googlecode/cqengine/index/sqlite/PartialSQLiteIndexTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/sqlite/PartialSQLiteIndexTest.java
@@ -3,7 +3,7 @@ package com.googlecode.cqengine.index.sqlite;
 import com.googlecode.cqengine.ConcurrentIndexedCollection;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.query.QueryFactory;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import com.googlecode.cqengine.testutil.Car;
 import com.googlecode.cqengine.testutil.CarFactory;
@@ -22,9 +22,9 @@ import static org.junit.Assert.assertEquals;
  */
 public class PartialSQLiteIndexTest {
 
-    public static final SimpleAttribute<Car, Integer> OBJECT_TO_ID = Car.CAR_ID;
+    public static final ISimpleAttribute<Car,Integer> OBJECT_TO_ID = Car.CAR_ID;
 
-    public static final SimpleAttribute<Integer, Car> ID_TO_OBJECT = new SimpleAttribute<Integer, Car>("carFromId") {
+    public static final ISimpleAttribute<Integer,Car> ID_TO_OBJECT = new SimpleAttribute<Integer, Car>("carFromId") {
         public Car getValue(Integer carId, QueryOptions queryOptions) { return CarFactory.createCar(carId); }
     };
 

--- a/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndexTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndexTest.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.cqengine.index.sqlite;
 
-import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.sqlite.TemporaryDatabase.TemporaryInMemoryDatabase;
 import com.googlecode.cqengine.testutil.Car;
 import com.googlecode.cqengine.testutil.CarFactory;
@@ -36,8 +36,8 @@ public class SQLiteIdentityIndexTest {
                 Car.CAR_ID
         );
 
-        SimpleAttribute<Car, byte[]> serializingAttribute = index.new SerializingAttribute(Car.class, byte[].class);
-        SimpleAttribute<byte[], Car> deserializingAttribute = index.new DeserializingAttribute(byte[].class, Car.class);
+        ISimpleAttribute<Car,byte[]> serializingAttribute = index.new SerializingAttribute(Car.class, byte[].class);
+        ISimpleAttribute<byte[],Car> deserializingAttribute = index.new DeserializingAttribute(byte[].class, Car.class);
 
         Car c1 = CarFactory.createCar(1);
         byte[] s1 = serializingAttribute.getValue(c1, noQueryOptions());

--- a/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIndexTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/sqlite/SQLiteIndexTest.java
@@ -17,6 +17,7 @@ package com.googlecode.cqengine.index.sqlite;
 
 import com.google.common.collect.*;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.sqlite.support.DBQueries;
 import com.googlecode.cqengine.index.support.CloseableIterable;
 import com.googlecode.cqengine.index.support.KeyStatistics;
@@ -59,9 +60,9 @@ public class SQLiteIndexTest {
     private static final String TABLE_NAME = "cqtbl_features";
     private static final String INDEX_NAME = "cqidx_features_value";
 
-    public static final SimpleAttribute<Car, Integer> OBJECT_TO_ID = Car.CAR_ID;
+    public static final ISimpleAttribute<Car,Integer> OBJECT_TO_ID = Car.CAR_ID;
 
-    public static final SimpleAttribute<Integer, Car> ID_TO_OBJECT = new SimpleAttribute<Integer, Car>("carFromId") {
+    public static final ISimpleAttribute<Integer,Car> ID_TO_OBJECT = new SimpleAttribute<Integer, Car>("carFromId") {
         public Car getValue(Integer carId, QueryOptions queryOptions) { return null; }
     };
 
@@ -478,7 +479,7 @@ public class SQLiteIndexTest {
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);
@@ -522,7 +523,7 @@ public class SQLiteIndexTest {
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);
@@ -570,7 +571,7 @@ public class SQLiteIndexTest {
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
 
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);
@@ -1014,7 +1015,7 @@ public class SQLiteIndexTest {
         Statement statement = mock(PreparedStatement.class);
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);
@@ -1058,7 +1059,7 @@ public class SQLiteIndexTest {
         Statement statement = mock(PreparedStatement.class);
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);
@@ -1113,7 +1114,7 @@ public class SQLiteIndexTest {
         java.sql.ResultSet resultSet = mock(java.sql.ResultSet.class);
 
         @SuppressWarnings("unchecked")
-        SimpleAttribute<Integer, Car> idToObject = (SimpleAttribute<Integer, Car>)mock(SimpleAttribute.class);
+        ISimpleAttribute<Integer,Car> idToObject = (ISimpleAttribute<Integer,Car>)mock(SimpleAttribute.class);
 
         // Behaviour
         when(connectionManager.getConnection(any(SQLiteIndex.class), anyQueryOptions())).thenReturn(connection);

--- a/code/src/test/java/com/googlecode/cqengine/persistence/PersistenceIndexingBenchmark.java
+++ b/code/src/test/java/com/googlecode/cqengine/persistence/PersistenceIndexingBenchmark.java
@@ -18,6 +18,7 @@ package com.googlecode.cqengine.persistence;
 import com.googlecode.cqengine.ConcurrentIndexedCollection;
 import com.googlecode.cqengine.IndexedCollection;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.index.disk.DiskIndex;
 import com.googlecode.cqengine.index.navigable.NavigableIndex;
 import com.googlecode.cqengine.index.offheap.OffHeapIndex;
@@ -61,7 +62,7 @@ public class PersistenceIndexingBenchmark {
         }
     }
 
-    static final SimpleAttribute<Car, String> CAR_ID_STRING = new SimpleAttribute<Car, String>("carIdString") {
+    static final ISimpleAttribute<Car,String> CAR_ID_STRING = new SimpleAttribute<Car, String>("carIdString") {
         @Override
         public String getValue(Car car, QueryOptions queryOptions) {
             return String.valueOf(car.getCarId());

--- a/code/src/test/java/com/googlecode/cqengine/testutil/Car.java
+++ b/code/src/test/java/com/googlecode/cqengine/testutil/Car.java
@@ -16,7 +16,9 @@
 package com.googlecode.cqengine.testutil;
 
 import com.googlecode.cqengine.attribute.MultiValueAttribute;
+import com.googlecode.cqengine.attribute.IMultiValueAttribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.ISimpleAttribute;
 import com.googlecode.cqengine.query.option.QueryOptions;
 
 import java.util.List;
@@ -26,31 +28,31 @@ import java.util.List;
  */
 public class Car {
 
-    public static final SimpleAttribute<Car, Integer> CAR_ID = new SimpleAttribute<Car, Integer>("carId") {
+    public static final ISimpleAttribute<Car,Integer> CAR_ID = new SimpleAttribute<Car, Integer>("carId") {
         public Integer getValue(Car car, QueryOptions queryOptions) { return car.carId; }
     };
 
-    public static final SimpleAttribute<Car, String> MANUFACTURER = new SimpleAttribute<Car, String>("manufacturer") {
+    public static final ISimpleAttribute<Car,String> MANUFACTURER = new SimpleAttribute<Car, String>("manufacturer") {
         public String getValue(Car car, QueryOptions queryOptions) { return car.manufacturer; }
     };
 
-    public static final SimpleAttribute<Car, String> MODEL = new SimpleAttribute<Car, String>("model") {
+    public static final ISimpleAttribute<Car,String> MODEL = new SimpleAttribute<Car, String>("model") {
         public String getValue(Car car, QueryOptions queryOptions) { return car.model; }
     };
 
-    public static final SimpleAttribute<Car, Color> COLOR = new SimpleAttribute<Car, Color>("color") {
+    public static final ISimpleAttribute<Car,Color> COLOR = new SimpleAttribute<Car, Color>("color") {
         public Color getValue(Car car, QueryOptions queryOptions) { return car.color; }
     };
 
-    public static final SimpleAttribute<Car, Integer> DOORS = new SimpleAttribute<Car, Integer>("doors") {
+    public static final ISimpleAttribute<Car,Integer> DOORS = new SimpleAttribute<Car, Integer>("doors") {
         public Integer getValue(Car car, QueryOptions queryOptions) { return car.doors; }
     };
 
-    public static final SimpleAttribute<Car, Double> PRICE = new SimpleAttribute<Car, Double>("price") {
+    public static final ISimpleAttribute<Car,Double> PRICE = new SimpleAttribute<Car, Double>("price") {
         public Double getValue(Car car, QueryOptions queryOptions) { return car.price; }
     };
 
-    public static final MultiValueAttribute<Car, String> FEATURES = new MultiValueAttribute<Car, String>("features") {
+    public static final IMultiValueAttribute<Car,String> FEATURES = new MultiValueAttribute<Car, String>("features") {
         public Iterable<String> getValues(Car car, QueryOptions queryOptions) { return car.features; }
     };
 


### PR DESCRIPTION
This is is very useful for projects that don't or can't use the existing hierarchy
of attributes provided by CQEngine but would benefit from optimizations
provided by it by explicitly conforming to interfaces that describe
those specialized attributes.

Closes #80