### PR TITLE
UniqueIndex query performance improvement

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/ConcurrentIndexedCollection.java
+++ b/code/src/main/java/com/googlecode/cqengine/ConcurrentIndexedCollection.java
@@ -68,7 +68,7 @@ public class ConcurrentIndexedCollection<O> implements IndexedCollection<O> {
     protected final Persistence<O, ?> persistence;
     protected final ObjectStore<O> objectStore;
     protected final QueryEngineInternal<O> indexEngine;
-    protected final QueryOptions defaultOptions;
+
     /**
      * Creates a new {@link ConcurrentIndexedCollection} with default settings, using {@link OnHeapPersistence}.
      */
@@ -86,9 +86,6 @@ public class ConcurrentIndexedCollection<O> implements IndexedCollection<O> {
      */
     public ConcurrentIndexedCollection(Persistence<O, ? extends Comparable> persistence) {
         this.persistence = persistence;
-        this.defaultOptions = new QueryOptions();
-        this.defaultOptions.put(Persistence.class, persistence);
-        FlagsEnabled.forQueryOptions(this.defaultOptions).add(PersistenceFlags.READ_REQUEST);
         this.objectStore = persistence.createObjectStore();
         QueryEngineInternal<O> queryEngine = new CollectionQueryEngine<O>();
         QueryOptions queryOptions = openRequestScopeResourcesIfNecessary(null);
@@ -109,6 +106,7 @@ public class ConcurrentIndexedCollection<O> implements IndexedCollection<O> {
     @Override
     public ResultSet<O> retrieve(Query<O> query) {
         final QueryOptions queryOptions = openRequestScopeResourcesIfNecessary(null);
+        flagAsReadRequest(queryOptions);
         ResultSet<O> results = indexEngine.retrieve(query, queryOptions);
         return new CloseableResultSet<O>(results, query, queryOptions) {
             @Override
@@ -489,13 +487,12 @@ public class ConcurrentIndexedCollection<O> implements IndexedCollection<O> {
 
     protected QueryOptions openRequestScopeResourcesIfNecessary(QueryOptions queryOptions) {
         if (queryOptions == null) {
-            queryOptions = defaultOptions;
-        } else {
-            queryOptions.put(Persistence.class, persistence);
+            queryOptions = new QueryOptions();
         }
         if (!(persistence instanceof OnHeapPersistence)) {
             persistence.openRequestScopeResources(queryOptions);
         }
+        queryOptions.put(Persistence.class, persistence);
         return queryOptions;
     }
 


### PR DESCRIPTION
I've been comparing cqengine indexed collection with UniqueIndex vs java HashMap. Got following results with cqengine build from the master branch.

 Benchmark | isRandom |  Mode | Cnt | Score | Units
 --------- | --------- | ---- | --- | ----- | -----
QueryTest.queryHash | true | thrpt | 2 | 1901168.875 | ops/s
QueryTest.queryHash | false | thrpt | 2 | 2105789.060 | ops/s
QueryTest.uniqueQuery | true | thrpt | 2 | 624565.412 | ops/s
QueryTest.uniqueQuery | false | thrpt | 2 | 696505.702 | ops/s

Here I see cqengine is 3 TIMES slower, while having quite the same hashmap in the UinqueIndex. 
After analyzing the bottleneck I got the patch with performance pretty close to what I'd expect to have with cqengine and UniqueIndex:

 Benchmark | isRandom |  Mode | Cnt | Score | Units
 --------- | --------- | ---- | --- | ----- | -----
QueryTest.queryHash | true | thrpt | 2 | 1956465.422 | ops/s
QueryTest.queryHash | false | thrpt | 2 | 2108939.911 | ops/s
QueryTest.uniqueQuery | true | thrpt | 2 | 1850139.358 | ops/s
QueryTest.uniqueQuery | false | thrpt | 2 | 1854801.132 | ops/s

All cqengine build tests run smooth so I do not expect to broke anything. 
Please review and include to the cqengine streamline if possible.

I've been using JMH harness and test project is [here](https://github.com/uujava/cqengine-query-jmh).
I was running two tests from this [perf.query.QueryTest](https://github.com/uujava/cqengine-query-jmh/blob/master/src/main/java/ru/programpark/tests/perf/query/QueryTest.java) like below: 
```
java -jar target\benchmarks.jar query.QueryTest.uniqueQuery -jvmArgs "-Xmx1300m -Xms1300m -XX:+UseG1GC" -r 10
java -jar target\benchmarks.jar query.QueryTest.hashQuery -jvmArgs "-Xmx1300m -Xms1300m -XX:+UseG1GC" -r 10
```
My environment: Maven 3.3.9, Java8 b102 64bit, Win7 64bit
Hardware: Intel Core2 Quad Q9000 CPU 2Ghz, 8Gb

