### PR TITLE
check for dirty indexes before add it to a collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/code/src/main/java/com/googlecode/cqengine/engine/CollectionQueryEngine.java
+++ b/code/src/main/java/com/googlecode/cqengine/engine/CollectionQueryEngine.java
@@ -82,6 +82,8 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
     // A key used to store the root query in the QueryOptions, so it may be accessed by partial indexes...
     public static final String ROOT_QUERY = "ROOT_QUERY";
 
+    public static final String DISABLE_DIRTY_CHECK_OPTION = "DISABLE_DIRTY_CHECK";
+
     private volatile Persistence<O, ? extends Comparable> persistence;
     private volatile ObjectStore<O> objectStore;
 
@@ -171,6 +173,10 @@ public class CollectionQueryEngine<O> implements QueryEngineInternal<O> {
      * @param <A> The type of objects indexed
      */
     <A> void addAttributeIndex(AttributeIndex<A, O> attributeIndex, QueryOptions queryOptions) {
+        Object dirtyCheck = queryOptions.get(DISABLE_DIRTY_CHECK_OPTION);
+        if (dirtyCheck == null || !(Boolean) dirtyCheck) {
+            attributeIndex.checkDirty();
+        }
         Attribute<O, A> attribute = attributeIndex.getAttribute();
         Set<Index<O>> indexesOnThisAttribute = attributeIndexes.get(attribute);
         if (indexesOnThisAttribute == null) {

--- a/code/src/main/java/com/googlecode/cqengine/index/AttributeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/AttributeIndex.java
@@ -31,4 +31,9 @@ public interface AttributeIndex<A, O> extends Index<O> {
      * @return The attribute indexed by this index
      */
     Attribute<O, A> getAttribute();
+
+    /**
+     * Checks if this index is alredy being used by another collection.
+     */
+    void checkDirty();
 }

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/SQLiteIdentityIndex.java
@@ -20,10 +20,7 @@ import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
 import com.googlecode.cqengine.index.Index;
 import com.googlecode.cqengine.index.sqlite.support.PojoSerializer;
-import com.googlecode.cqengine.index.support.CloseableIterable;
-import com.googlecode.cqengine.index.support.KeyStatistics;
-import com.googlecode.cqengine.index.support.KeyValue;
-import com.googlecode.cqengine.index.support.SortedKeyStatisticsAttributeIndex;
+import com.googlecode.cqengine.index.support.*;
 import com.googlecode.cqengine.index.support.indextype.NonHeapTypeIndex;
 import com.googlecode.cqengine.persistence.support.ObjectSet;
 import com.googlecode.cqengine.persistence.support.ObjectStore;
@@ -50,6 +47,7 @@ public class SQLiteIdentityIndex<A extends Comparable<A>, O> implements Identity
     final Class<O> objectType;
     final SimpleAttribute<O, A> primaryKeyAttribute;
     final SimpleAttribute<A, O> foreignKeyAttribute;
+    private boolean dirty = false;
 
     public SQLiteIdentityIndex(final SimpleAttribute<O, A> primaryKeyAttribute) {
         this.sqLiteIndex = new SQLiteIndex<A, O, byte[]>(
@@ -78,6 +76,14 @@ public class SQLiteIdentityIndex<A extends Comparable<A>, O> implements Identity
     @Override
     public Attribute<O, A> getAttribute() {
         return sqLiteIndex.getAttribute();
+    }
+
+    @Override
+    public void checkDirty() {
+        if (dirty) {
+            throw new AbstractAttributeIndex.DirtyIndexException("Index of attribute: " + primaryKeyAttribute.getAttributeName() + " - is in use.");
+        }
+        dirty = true;
     }
 
     @Override

--- a/code/src/main/java/com/googlecode/cqengine/index/sqlite/SimplifiedSQLiteIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/sqlite/SimplifiedSQLiteIndex.java
@@ -44,6 +44,7 @@ public abstract class SimplifiedSQLiteIndex<A extends Comparable<A>, O, K extend
     final Attribute<O, A> attribute;
     final String tableNameSuffix;
     volatile SQLiteIndex<A, O, K> backingIndex;
+    private boolean dirty = false;
 
     protected SimplifiedSQLiteIndex(Class<? extends SQLitePersistence<O, A>> persistenceType, Attribute<O, A> attribute, String tableNameSuffix) {
         this.persistenceType = persistenceType;
@@ -247,5 +248,13 @@ public abstract class SimplifiedSQLiteIndex<A extends Comparable<A>, O, K extend
         int result = getClass().hashCode();
         result = 31 * result + attribute.hashCode();
         return result;
+    }
+
+    @Override
+    public void checkDirty() {
+        if (dirty) {
+            throw new AbstractAttributeIndex.DirtyIndexException("Index of attribute: " + attribute.getAttributeName() + " - is in use.");
+        }
+        dirty = true;
     }
 }

--- a/code/src/main/java/com/googlecode/cqengine/index/support/AbstractAttributeIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/support/AbstractAttributeIndex.java
@@ -38,6 +38,8 @@ public abstract class AbstractAttributeIndex<A, O> implements AttributeIndex<A, 
 
     protected final Attribute<O, A> attribute;
 
+    private boolean dirty = false;
+
     /**
      * Protected constructor, called by subclasses.
      *
@@ -58,6 +60,19 @@ public abstract class AbstractAttributeIndex<A, O> implements AttributeIndex<A, 
      */
     public Attribute<O, A> getAttribute() {
         return attribute;
+    }
+
+    public static class DirtyIndexException extends RuntimeException {
+        public DirtyIndexException(String message) {
+            super(message);
+        }
+    }
+
+    public void checkDirty() {
+        if (dirty) {
+            throw new DirtyIndexException("Index of attribute: " + attribute.getAttributeName() + " - is in use.");
+        }
+        dirty = true;
     }
 
     /**

--- a/code/src/main/java/com/googlecode/cqengine/index/support/PartialIndex.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/support/PartialIndex.java
@@ -90,6 +90,7 @@ public abstract class PartialIndex<A, O, I extends AttributeIndex<A, O>> impleme
     protected final Query<O> filterQuery;
     protected final Attribute<O, A> attribute;
     protected volatile I backingIndex;
+    private boolean dirty = false;
 
     /**
      * Protected constructor, called by subclasses.
@@ -113,6 +114,13 @@ public abstract class PartialIndex<A, O, I extends AttributeIndex<A, O>> impleme
         return backingIndex;
     }
 
+    @Override
+    public void checkDirty() {
+        if (dirty) {
+            throw new AbstractAttributeIndex.DirtyIndexException("Index of attribute: " + attribute.getAttributeName() + " - is in use.");
+        }
+        dirty = true;
+    }
 
     public Attribute<O, A> getAttribute() {
         return backingIndex().getAttribute();


### PR DESCRIPTION
New feature/Constraint:
When a collection with indexes is filled with data, you can have that indexes into separate variables or static fields.
Then you could add this indexes to a new collection (p.ex the same collection but re-instantiated from a persistence serialization system), but this indexes can have data and can associate with the new collection silent and dirty.
This checks that the index was used and is dirty and throws an exception to warn the user.

If you let this with the QueryOption you assume that you could have indexes with different data on multiple collections, or data into the index that could be changed into the collection after a de-serialization process

Added new QueryOption DISABLE_DIRTY_CHECK_OPTION boolean that handles the deactivation of the newfeature/constraint. This check is disabled by default.
