### PR TITLE
Enable compound indices and queries to work regardless of ordering

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/index/compound/support/CompoundValueTuple.java
+++ b/code/src/main/java/com/googlecode/cqengine/index/compound/support/CompoundValueTuple.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2012-2015 Niall Gallagher
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +17,12 @@ package com.googlecode.cqengine.index.compound.support;
 
 import com.googlecode.cqengine.attribute.Attribute;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A tuple (ordered list) of values, extracted from the fields of an object, according to, and in the same order as, the
@@ -35,8 +39,8 @@ public class CompoundValueTuple<O> {
     private final List<?> attributeValues;
     private final int hashCode;
 
-    public CompoundValueTuple(List<?> attributeValues) {
-        this.attributeValues = attributeValues;
+    public CompoundValueTuple(Map<Attribute<O, ?>, ?> attributeToValues) {
+        this.attributeValues = getOrderedAttributeValues(attributeToValues);
         this.hashCode = attributeValues.hashCode();
     }
 
@@ -68,5 +72,26 @@ public class CompoundValueTuple<O> {
                 "attributeValues=" + attributeValues +
                 ", hashCode=" + hashCode +
                 '}';
+    }
+
+    /**
+     * Given attribute values, sort them to ensure that compound index entries in the index engine
+     * work regardless of how the given CompoundQuery is ordered
+     * <p>
+     * Note: to be more specific, without this, the {@code equals} method will return false when
+     * two CompoundValueTuples contain the same values but are ordered differently
+     *
+     * @param attributeToValues a map of attributes and their corresponding values that were extracted from an object or query
+     * @return a list of ordered attribute values that will be used in this CompoundValueTuple
+     */
+    private static <O> List<?> getOrderedAttributeValues(Map<Attribute<O, ?>, ?> attributeToValues) {
+        final TreeMap<Attribute<O, ?>, Object> attributeValuesSortedByAttributeName = new TreeMap<Attribute<O, ?>, Object>(new Comparator<Attribute<O, ?>>() {
+            @Override
+            public int compare(Attribute<O, ?> o1, Attribute<O, ?> o2) {
+                return o1.getAttributeName().compareTo(o2.getAttributeName());
+            }
+        });
+        attributeValuesSortedByAttributeName.putAll(attributeToValues);
+        return new ArrayList<Object>(attributeValuesSortedByAttributeName.values());
     }
 }

--- a/code/src/test/java/com/googlecode/cqengine/IndexedCollectionFunctionalTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/IndexedCollectionFunctionalTest.java
@@ -15,6 +15,7 @@
  */
 package com.googlecode.cqengine;
 
+import com.google.common.collect.ImmutableMap;
 import com.googlecode.cqengine.attribute.Attribute;
 import com.googlecode.cqengine.attribute.SimpleAttribute;
 import com.googlecode.cqengine.attribute.StandingQueryAttribute;
@@ -524,7 +525,7 @@ public class IndexedCollectionFunctionalTest {
                                             String manufacturer = (String) tupleValues.next();
                                             String model = (String) tupleValues.next();
                                             String quantizedModel = "Focus".equals(model) ? "Focus" : "Other";
-                                            return new CompoundValueTuple<Car>(Arrays.asList(manufacturer, quantizedModel));
+                                            return new CompoundValueTuple<Car>(ImmutableMap.<Attribute<Car, ?>, Object>of(Car.MANUFACTURER, manufacturer, Car.MODEL, quantizedModel));
                                         }
                                     }, Car.MANUFACTURER, Car.MODEL)
                             ),

--- a/code/src/test/java/com/googlecode/cqengine/index/compound/support/ScrambledQueriesTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/index/compound/support/ScrambledQueriesTest.java
@@ -1,0 +1,71 @@
+package com.googlecode.cqengine.index.compound.support;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.cqengine.ConcurrentIndexedCollection;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.examples.introduction.Car;
+import com.googlecode.cqengine.index.compound.CompoundIndex;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.logical.And;
+import com.googlecode.cqengine.resultset.ResultSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.googlecode.cqengine.query.QueryFactory.and;
+import static com.googlecode.cqengine.query.QueryFactory.equal;
+
+/**
+ * @author Eduardo Barrios
+ */
+public class ScrambledQueriesTest {
+
+    private final IndexedCollection<Car> cars = new ConcurrentIndexedCollection<Car>();
+
+    @Before
+    public void setUp() {
+        // add the index we want to test
+        cars.addIndex(CompoundIndex.onAttributes(Car.CAR_ID, Car.NAME, Car.DESCRIPTION, Car.FEATURES));
+
+        // Add some objects to the collection...
+        cars.add(new Car(1, "ford", "focus", ImmutableList.of("fwd", "hatchback", "black")));
+        cars.add(new Car(2, "honda", "civic", ImmutableList.of("fwd", "sedan", "silver")));
+        cars.add(new Car(3, "toyota", "prius", ImmutableList.of("hybrid", "fwd", "blue")));
+        cars.add(new Car(4, "ford", "explorer", ImmutableList.of("awd", "green")));
+        cars.add(new Car(5, "honda", "crv", ImmutableList.of("awd", "black")));
+        cars.add(new Car(6, "toyota", "tundra", ImmutableList.of("4x4", "red")));
+    }
+
+    @Test
+    public void testUnscrambleQuery() {
+
+        Query<Car> scrambledQuery = and(
+                equal(Car.NAME, "ford"),
+                equal(Car.FEATURES, "black"),
+                equal(Car.CAR_ID, 1),
+                equal(Car.DESCRIPTION, "focus")
+        );
+        ResultSet<Car> flatQueryResult = cars.retrieve(scrambledQuery);
+        Assert.assertEquals(1, flatQueryResult.size());
+        Assert.assertEquals(20, flatQueryResult.getRetrievalCost());
+    }
+
+    @Test
+    public void testFlattenQuery() {
+        And<Car> nestedQuery = and(
+                equal(Car.CAR_ID, 1),
+                and(
+                        equal(Car.NAME, "ford"),
+                        and(
+                                equal(Car.DESCRIPTION, "focus"),
+                                equal(Car.FEATURES, "black")
+                        )
+                )
+        );
+
+        ResultSet<Car> nestedQueryResult = cars.retrieve(nestedQuery);
+        Assert.assertEquals(1, nestedQueryResult.size());
+        Assert.assertEquals(20, nestedQueryResult.getRetrievalCost());
+
+    }
+}


### PR DESCRIPTION
Enable compound queries to use compound indices even if the attributes are specified in different order