### PR TITLE
Added benchmark for materialized order operation

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/resultset/iterator/IteratorUtil.java
+++ b/code/src/main/java/com/googlecode/cqengine/resultset/iterator/IteratorUtil.java
@@ -183,7 +183,7 @@ public class IteratorUtil {
 
     /**
      * Sorts the results returned by the given iterator, returning the sorted results as a new iterator, by performing
-     * an insertion-sort into an intermediate set in memory.
+     * an merge-sort into an intermediate array in memory.
      * <p/>
      * Time complexity for building an insertion sorted set is <code>O(merge_cost * log(merge_cost))</code>, and then
      * iterating it makes this <b><code>O(merge_cost^2 * log(merge_cost))</code></b>. (Merge cost is an approximation
@@ -195,11 +195,12 @@ public class IteratorUtil {
      * @return An iterator which returns the objects in sorted order
      */
     public static <O> Iterator<O> materializedSort(Iterator<O> unsortedIterator, Comparator<O> comparator) {
-        Set<O> materializedSet = new TreeSet<O>(comparator);
+        final List<O> result = new ArrayList<>();
         while (unsortedIterator.hasNext()) {
-            materializedSet.add(unsortedIterator.next());
+            result.add(unsortedIterator.next());
         }
-        return materializedSet.iterator();
+        result.sort(comparator);
+        return result.iterator();
     }
 
     /**

--- a/code/src/test/java/com/googlecode/cqengine/benchmark/BenchmarkRunner.java
+++ b/code/src/test/java/com/googlecode/cqengine/benchmark/BenchmarkRunner.java
@@ -49,7 +49,8 @@ public class BenchmarkRunner {
             new NonOptimalIndexes_ManufacturerToyotaColorBlueDoorsThree(),
             new StandingQueryIndex_ManufacturerToyotaColorBlueDoorsNotFive(),
             new RadixTreeIndex_ModelStartsWithP(),
-            new SuffixTreeIndex_ModelContainsG()
+            new SuffixTreeIndex_ModelContainsG(),
+            new MaterializedOrder_CardId()
     );
 
     public static void main(String[] args) {

--- a/code/src/test/java/com/googlecode/cqengine/benchmark/BenchmarkUnitTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/benchmark/BenchmarkUnitTest.java
@@ -153,4 +153,15 @@ public class BenchmarkUnitTest {
         assertEquals(100, task.runQueryCountResults_CQEngine());
         assertEquals(100, task.runQueryCountResults_CQEngineStatistics());
     }
+
+    @Test
+    public void testMaterializedOrder_CardId() {
+        BenchmarkTask task = new MaterializedOrder_CardId();
+        task.init(collection);
+
+        assertEquals(1000, task.runQueryCountResults_IterationNaive());
+        assertEquals(1000, task.runQueryCountResults_IterationOptimized());
+        assertEquals(1000, task.runQueryCountResults_CQEngine());
+        assertEquals(1000, task.runQueryCountResults_CQEngineStatistics());
+    }
 }

--- a/code/src/test/java/com/googlecode/cqengine/benchmark/tasks/MaterializedOrder_CardId.java
+++ b/code/src/test/java/com/googlecode/cqengine/benchmark/tasks/MaterializedOrder_CardId.java
@@ -1,0 +1,73 @@
+package com.googlecode.cqengine.benchmark.tasks;
+
+import com.googlecode.cqengine.ConcurrentIndexedCollection;
+import com.googlecode.cqengine.IndexedCollection;
+import com.googlecode.cqengine.benchmark.BenchmarkTask;
+import com.googlecode.cqengine.query.Query;
+import com.googlecode.cqengine.query.option.QueryOptions;
+import com.googlecode.cqengine.resultset.ResultSet;
+import com.googlecode.cqengine.testutil.Car;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+
+import static com.googlecode.cqengine.query.QueryFactory.all;
+import static com.googlecode.cqengine.query.QueryFactory.ascending;
+import static com.googlecode.cqengine.query.QueryFactory.orderBy;
+import static com.googlecode.cqengine.query.QueryFactory.queryOptions;
+
+public class MaterializedOrder_CardId  implements BenchmarkTask {
+    private Collection<Car> collection;
+    private IndexedCollection<Car> indexedCollection;
+
+    private final Comparator<Car> carIdComparator = Comparator.comparingInt(Car::getCarId);
+
+    private final Query<Car> query = all(Car.class);
+    private final QueryOptions queryOptions = queryOptions(orderBy(ascending(Car.CAR_ID)));
+    @Override
+    public void init(final Collection<Car> collection) {
+        this.collection = collection;
+        this.indexedCollection = new ConcurrentIndexedCollection<>();
+
+        this.indexedCollection.addAll(collection);
+    }
+
+    @Override
+    public int runQueryCountResults_IterationNaive() {
+        final TreeSet<Car> sortedSet = new TreeSet<>(carIdComparator);
+        for (final Car car : collection) {
+            sortedSet.add(car);
+        }
+        final List<Car> result = new ArrayList<>(sortedSet);
+        return result.size();
+    }
+
+    @Override
+    public int runQueryCountResults_IterationOptimized() {
+        final List<Car> result = new ArrayList<>(collection.size());
+        for (final Car car : collection) {
+            result.add(car);
+        }
+        result.sort(carIdComparator);
+        return result.size();
+    }
+
+    @Override
+    public int runQueryCountResults_CQEngine() {
+        final ResultSet<Car> sortedResult = indexedCollection.retrieve(query, queryOptions);
+        final List<Car> result = new ArrayList<>();
+        for (final Car car : sortedResult) {
+            result.add(car);
+        }
+        return result.size();
+    }
+
+    @Override
+    public int runQueryCountResults_CQEngineStatistics() {
+        final ResultSet<Car> result = indexedCollection.retrieve(query, queryOptions);
+        return result.size();
+    }
+}


### PR DESCRIPTION
**Benchmark Expectation:** for a given collection of cars, create a sorted list of cars.

In the naive benchmark, I am using a tree set since that's a common way to sort values in Java. (similar to CQEngine)

In the optimized benchmark, I am using an ArrayList's sort implementation, since it's very optimized and uses an algorithm that can make less an n log(n) comparisons to sort.

In the CQEngine Query benchmark, i use the orderby option to query the values and then add it to a list, since the expected output is always a list.

In the CQEngine Statistics benchmark, i am using `ResultSet::size` method, this doesn't actually sort the collection but that's an optimization that CQEngine does internally. 

-------
Benchmark output on my 2019 Macbook Pro

|TestName|	IterationNaive|	IterationOptimized|	CQEngine|	CQEngineStatistics|
|  ----| ----|-----|-----|-----|
|MaterializedOrder_CardId|	15,370,744|	2,346,713|	43,762,988|	1,374,745|