### PR TITLE
http://htmlpreview.github.io/ is broken, use github pages instead?

### DIFF
--- a/.github/workflows/publish-javadoc-to-github-pages.yml
+++ b/.github/workflows/publish-javadoc-to-github-pages.yml
@@ -1,0 +1,17 @@
+name: Publish Javadoc to GitHub Pages
+on: 
+  push:
+    branches:
+      - 'master'
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: documentation/javadoc/apidocs # The folder the action should deploy.


### PR DESCRIPTION
htmlpreview doesn't work very well, it butchers the stylesheets. This adds a CI action that literally just copies the documentation/javadoc/apidocs into a gh-pages branch. You can then enable github pages in `Settings` to publish the javadoc using github which seems to work much better

Compare: [Github Pages](https://rubydesic.github.io/cqengine/com/googlecode/cqengine/engine/QueryEngine.html#addIndex(com.googlecode.cqengine.index.Index)) vs [htmlpreview](http://htmlpreview.github.io/?http://raw.githubusercontent.com/npgall/cqengine/master/documentation/javadoc/apidocs/com/googlecode/cqengine/engine/QueryEngine.html#addIndex(com.googlecode.cqengine.index.Index))



