### PR TITLE
Updates filtering iterator to have a consistent hasNext method #291

### DIFF
--- a/code/src/main/java/com/googlecode/cqengine/resultset/filter/FilteringIterator.java
+++ b/code/src/main/java/com/googlecode/cqengine/resultset/filter/FilteringIterator.java
@@ -41,10 +41,14 @@ public abstract class FilteringIterator<O> extends UnmodifiableIterator<O> {
 
     private O nextObject = null;
     private boolean nextObjectIsNull = false;
+    private boolean finished = false;
 
     @Override
     public boolean hasNext() {
-        if(nextObjectIsNull || nextObject != null) {
+        if (finished) {
+            return false;
+        }
+        if (nextObjectIsNull || nextObject != null) {
             return true;
         }
         while (wrappedIterator.hasNext()) {
@@ -55,6 +59,7 @@ public abstract class FilteringIterator<O> extends UnmodifiableIterator<O> {
             } // else object not valid, skip to next object
             nextObjectIsNull = false;
         }
+        finished = true;
         return false;
     }
 

--- a/code/src/test/java/com/googlecode/cqengine/engine/CollectionQueryEngineTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/engine/CollectionQueryEngineTest.java
@@ -39,6 +39,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.googlecode.cqengine.query.QueryFactory.*;
 import static com.googlecode.cqengine.resultset.iterator.IteratorUtil.countElements;
@@ -142,6 +145,21 @@ public class CollectionQueryEngineTest {
 
         // The two-branch or() query should have been evaluated by scanning the collection only once...
         Assert.assertEquals(iterationCountingSet.size(), iterationCountingSet.getItemsIteratedCount());
+    }
+
+    @Test
+    public void testFallbackIndexToStream() {
+        IndexedCollection<Car> collection = new ConcurrentIndexedCollection<Car>();
+        collection.addAll(CarFactory.createCollectionOfCars(10));
+
+        Query<Car> query = equal(Car.MANUFACTURER, "0xabc");
+        ResultSet<Car> resultSet = collection.retrieve(query);
+
+        List<Car> carsList = resultSet.stream().collect(Collectors.toList());
+        Iterator<Integer> carIds = resultSet.stream().map(Car::getCarId).iterator();
+
+        Assert.assertEquals(0, carsList.size());
+        Assert.assertFalse(carIds.hasNext());
     }
 
     @Test

--- a/code/src/test/java/com/googlecode/cqengine/resultset/filter/FilteringIteratorTest.java
+++ b/code/src/test/java/com/googlecode/cqengine/resultset/filter/FilteringIteratorTest.java
@@ -84,6 +84,37 @@ public class FilteringIteratorTest {
         assertThat(iterator.hasNext(), is(false));
     }
 
+    @Test
+    public void testFilteringState() {
+        List<String> testList = Arrays.asList("aaa", "bbb", "aab", "bba");
+        FilteringIterator<String> iterator = new FilteringIterator<String>(testList.iterator(), noQueryOptions()) {
+            @Override
+            public boolean isValid(String object, QueryOptions queryOptions) {
+                return false;
+            }
+        };
+
+        assertThat(iterator.hasNext(), is(false));
+        assertThat(iterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void testFilterNullValues() {
+        List<String> testList = Arrays.asList("aaa", null, "aab", "bba");
+        FilteringIterator<String> iterator = new FilteringIterator<String>(testList.iterator(), noQueryOptions()) {
+            @Override
+            public boolean isValid(String object, QueryOptions queryOptions) {
+                return true;
+            }
+        };
+
+        assertThat(iterator.hasNext(), is(true));
+        assertThat("first string value", iterator.next(), is("aaa"));
+        assertThat(iterator.hasNext(), is(true));
+        assertThat("second null value", iterator.next(), nullValue());
+        assertThat(iterator.hasNext(), is(true));
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void testEmptyDelegate() {
         List<String> testList = Arrays.asList();


### PR DESCRIPTION
With this change FilteringIterator will continue to return `hasNext` = false once it's consumed all the values from the underlying iterator.

The old behaviour of returning `null` values from the underlying iterator is maintained for backwards compatibility.

Added tests for FilteringIterator and the buggy behaviour observed in CollectionsQueryEngine when FilteringIterator is used due to FallbackIndex.