### PR TITLE
#307 - add support for ANLTR 4.10.1

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.7</version>
+                <version>4.10.1</version>
                 <executions>
                     <execution>
                         <id>antlr</id>
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.7.2</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>net.jodah</groupId>


### PR DESCRIPTION
In order to use CQEngine with more recent versions of ANTLR, e.g. as are transitively included and needed for Hibernate 6 - the following pom change will regenerate lexers for that ANTLR (4.10.1) version.