### PR TITLE
Bugfix/vulnerability

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.27.2.1</version>
+            <version>3.42.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware</groupId>

--- a/documentation/ReleaseNotes.md
+++ b/documentation/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # CQEngine Release Notes #
 
+## Version 3.6.1 - 2023-07-17 ###
+* Updated sqlite-jdbc dependency to remove transitive dependency vulnerability with score 8.8 (according to Snyk https://security.snyk.io/vuln/SNYK-JAVA-ORGXERIAL-5596891)
+
 ## Version 3.6.0 - 2021-01-15 ###
   * Performance improvement when ordering results (potentially up to 5-6X), with thanks to @voldyman for the contribution
     * See pull request https://github.com/npgall/cqengine/pull/273 for performance analysis


### PR DESCRIPTION
Updated sqlite-jdbc dependency to remove transitive dependency vulnerability with score 8.8 (according to Snyk https://security.snyk.io/vuln/SNYK-JAVA-ORGXERIAL-5596891)
@npgall @Melozzola @voldyman @devinrsmith @kimptoc @gzsombor @glockhart 